### PR TITLE
Refactor /code route so that variables are set at the right time

### DIFF
--- a/portal/profiles/views.py
+++ b/portal/profiles/views.py
@@ -65,10 +65,13 @@ class UserEdit(LoginRequiredMixin, UserPassesTestMixin, generic.UpdateView):
 def code(request):
     token = os.getenv("AUTHORIZATION")
 
+    diagnosis_code = '0000 0000'
+
     if token:
         try:
             r = requests.post(os.getenv("ENDPOINT"), headers={'Authorization': 'Bearer ' + token})
             r.raise_for_status()  # If we don't get a valid response, throw an exception
+            diagnosis_code = r.text
         except requests.exceptions.HTTPError as err:
             sys.stderr.write("Received " + str(r.status_code) + " " + err.response.text)
             sys.stderr.flush()
@@ -76,12 +79,7 @@ def code(request):
             sys.stderr.write('Something went wrong')
             sys.stderr.flush()
 
-        diagnosis_code = r.text
-        # Split up the code with a space in the middle so it looks like this: 1234 5678
-        diagnosis_code = diagnosis_code[0:4] + ' ' + diagnosis_code[4:8]
+    # Split up the code with a space in the middle so it looks like this: 1234 5678
+    diagnosis_code = diagnosis_code[0:4] + ' ' + diagnosis_code[4:8]
 
-    else:
-        diagnosis_code = '0000 0000'
-
-    context = {'code': diagnosis_code}
-    return render(request, 'profiles/code.html', context)
+    return render(request, 'profiles/code.html', {'code': diagnosis_code})


### PR DESCRIPTION
`r` is only referenced in the try/catch block, not in the code afterwards. Set a default code so that there is a fallback for local development.