### PR TITLE
Make the code more prominent on the /code page

### DIFF
--- a/profiles/static/scss/_base.scss
+++ b/profiles/static/scss/_base.scss
@@ -59,7 +59,8 @@ ul {
   }
 }
 
-a, a:visited {
+a,
+a:visited {
   color: $color-blue-dark;
 }
 
@@ -69,8 +70,7 @@ h3,
 h4,
 h5,
 h6,
-#site-name
- {
+#site-name {
   font-family: "Lato", sans-serif;
   line-height: 1.33;
   font-weight: 600;
@@ -121,4 +121,13 @@ li:not(:last-of-type) {
 
 .visually-hidden {
   @include visuallyHidden();
+}
+
+#big-code {
+  display: inline-block;
+  background: #eff4f9;
+  padding: 0.75em 1em;
+  margin-bottom: 1em;
+  font-size: 1.5em;
+  border-radius: 10px;
 }

--- a/profiles/templates/profiles/code.html
+++ b/profiles/templates/profiles/code.html
@@ -4,7 +4,7 @@
 
 {% block content %}
     <h1>Provide patient with code</h1>
-    <code>{{ code }}</code>
+    <code id="big-code">{{ code }}</code>
 
     <h2>Instructions for patient</h2>
     <ol>


### PR DESCRIPTION
Means its easier to see, and looks more like the mocks.

## Screenshot

| before | after |
|--------|-------|
|  <img width="978" alt="Screen Shot 2020-06-19 at 3 52 07 PM" src="https://user-images.githubusercontent.com/2454380/85175235-0388b580-b245-11ea-8818-6a3196eb7a29.png">   |  <img width="978" alt="Screen Shot 2020-06-19 at 3 52 09 PM" src="https://user-images.githubusercontent.com/2454380/85175217-fd92d480-b244-11ea-9a71-f61fb0c44f10.png">  |

