### PR TITLE
Use heroku.yml instead of Profile for Review Apps

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: python manage.py migrate; python manage.py sass profiles/assets/scss/ profiles/static/css/; python manage.py collectstatic --noinput; gunicorn portal.wsgi --log-file -

--- a/app.json
+++ b/app.json
@@ -1,0 +1,19 @@
+{
+  "name": "healthcare-portal",
+  "stack": "container",
+  "addons": ["heroku-postgresql:hobby-dev"],
+  "environments": {
+    "review": {
+      "env": {
+        "DJANGO_DEBUG": "True",
+        "DJANGO_ENV": "development"
+      }
+    },
+    "staging": {
+      "env": {
+        "DJANGO_DEBUG": "False",
+        "DJANGO_ENV": "production"
+      }
+    }
+  }
+}

--- a/heroku.yml
+++ b/heroku.yml
@@ -1,0 +1,9 @@
+build:
+  docker:
+    web: Dockerfile
+run:
+  web: |
+    python manage.py sass profiles/assets/scss/ profiles/static/css/
+    python manage.py collectstatic --noinput
+    python manage.py migrate
+    gunicorn portal.wsgi --log-file -


### PR DESCRIPTION
Using `heroku.yml`, we can deploy our app as a container, passing in different environment variables and allowing for different environments.

Basically, the `Procfile` is replaced by an `heroku.json` file, and the `app.json` file lets us set env vars based on where we're going to run our app.

Will have to do some manual setup once this is merged, but then we're all good.