### PR TITLE
Remove /invitations/send-invite URL

### DIFF
--- a/portal/urls.py
+++ b/portal/urls.py
@@ -3,6 +3,7 @@ from django.urls import path, include, re_path
 from django.http import HttpResponse
 from django.conf.urls.i18n import i18n_patterns
 from axes.admin import AccessLogAdmin
+from invitations.views import AcceptInvite
 
 from .admin import Admin2FASite
 
@@ -29,7 +30,19 @@ urlpatterns = [
     path("i18n/", include("django.conf.urls.i18n")),
 ]
 
+invitation_patterns = (
+    [
+        # https://github.com/bee-keeper/django-invitations/blob/master/invitations/urls.py
+        re_path(
+            r"^accept-invite/(?P<key>\w+)/?$",
+            AcceptInvite.as_view(),
+            name="accept-invite",
+        ),
+    ],
+    "invitations",
+)
+
 urlpatterns += i18n_patterns(
     path("", include("profiles.urls")),
-    path("invitations/", include("invitations.urls", namespace="invitations"),),
+    path("invitations/", include(invitation_patterns, namespace="invitations"),),
 )


### PR DESCRIPTION
As pointed out in the Blackberry security assessment, regular users can invite other users by manually typing in the URL because we added all of the URLs in the invitations plugin.

> Application uses external library, called django-invitations, to serve invitation feature for administrator and superuser roles. The application includes all views from external library. Two views from django-invitations require only logged-in user to sendinvitations.

This PR only includes the accept invite URL and removes the "create-invite" URL.

## Screenshot

This is the screen we were able to see: 

<img width="1210" alt="Screen Shot 2020-07-23 at 6 42 49 PM" src="https://user-images.githubusercontent.com/2454380/88345657-6d98ec80-cd14-11ea-84cc-f3f1b3dd8227.png">
