### PR TITLE
Remove autocomplete attributes from inputs

### DIFF
--- a/profiles/forms.py
+++ b/profiles/forms.py
@@ -31,6 +31,8 @@ class HealthcareBaseForm(forms.Form):
         # override field attributes: https://stackoverflow.com/a/56870308
         for field in self.fields:
             self.fields[field].widget.attrs.pop("autofocus", None)
+            # remove autocomplete attributes
+            self.fields[field].widget.attrs.update({"autocomplete": "off"})
 
 
 class HealthcareAuthenticationForm(HealthcareBaseForm, AuthenticationForm):

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -187,6 +187,8 @@ class AuthenticatedView(AdminUserTestCase):
         response = self.client.get(reverse("login"))
         self.assertEqual(response.status_code, 200)
         self.assertContains(response, "<h1>Log in</h1>")
+        self.assertContains(response, 'autocomplete="off"')
+
         #  Test logging in
         response = self.client.post("/en/login/", self.credentials, follow=True)
         self.assertTrue(response.context["user"].is_active)
@@ -309,14 +311,14 @@ class SignupFlow(AdminUserTestCase):
         # assert a disabled input with the email value exists
         self.assertContains(
             response,
-            '<input type="text" name="email" value="{}" required disabled id="id_email">'.format(
+            '<input type="text" name="email" value="{}" autocomplete="off" required disabled id="id_email">'.format(
                 self.invited_email
             ),
         )
         # assert a disabled input with the province value exists
         self.assertContains(
             response,
-            '<input type="hidden" name="province" value="{}" disabled id="id_province">'.format(
+            '<input type="hidden" name="province" value="{}" autocomplete="off" disabled id="id_province">'.format(
                 self.credentials["province"].abbr
             ),
         )


### PR DESCRIPTION
The BB security review flagged the autocomplete attribute as a risk.

The autocomplete attribute prompts the browser to remember the login details of the account that logged into the portal.

Since we don't want accounts on shared computers to be remembered, this is no good for us.

Sources:
- https://stackoverflow.com/questions/2580955/disable-autocomplete-on-textfield-in-django