### PR TITLE
Add numeric password validator + move name field to top of signup 

### DIFF
--- a/portal/settings.py
+++ b/portal/settings.py
@@ -156,6 +156,7 @@ AUTH_PASSWORD_VALIDATORS = [
         "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
         "OPTIONS": {"user_attributes": ["name", "username"]},
     },
+    {"NAME": "django.contrib.auth.password_validation.NumericPasswordValidator"},
     {"NAME": "profiles.validators.BannedPasswordValidator"},
 ]
 

--- a/profiles/forms.py
+++ b/profiles/forms.py
@@ -108,9 +108,9 @@ class SignupForm(HealthcareBaseForm, UserCreationForm):
     )
 
     field_order = [
+        "name",
         "email",
         "province",
-        "name",
         "phone_number",
         "phone_number_confirmation",
         "password1",


### PR DESCRIPTION
### Add the numeric password validator

I had assumed we wouldn't need the numeric password validator but Mark found it right away.

> Mark: hey here's a weird bug: so I went to test the new password controls by doing a reset on my 111111111111 password for my admin account. wouldn't let me set my password to 111111111111, nor would it accept 222222222222, but did accept 333333333333

> Mark: Yeah I'd add the NumericPasswordValidator one as well

Added in now, so your password can't be all 3s.

### Make the "name" field the first one on the sign in form
This is consistent with the Figma prototype that we've been following.

## Screenshot

![Screen Shot 2020-07-30 at 1 30 07 PM](https://user-images.githubusercontent.com/2454380/88954820-f4941a80-d268-11ea-8e5a-b9b4a86963c5.png)
