### PR TITLE
Red borders on textareas when errors

### DIFF
--- a/profiles/static/scss/components/forms/_input.scss
+++ b/profiles/static/scss/components/forms/_input.scss
@@ -1,5 +1,6 @@
 main form {
-  input, textarea {
+  input,
+  textarea {
     display: block;
     margin: 0;
     font-size: inherit;
@@ -22,12 +23,16 @@ main form {
     height: 2.5rem;
   }
 
-  .fieldWrapper--has-error input {
-    border: 2px solid $color-red;
+  .fieldWrapper--has-error {
+    input,
+    textarea {
+      border: 2px solid $color-red;
 
-    &:focus {
-      -webkit-box-shadow: inset 0 0 0 2px $color-red;
-      box-shadow: inset 0 0 0 2px $color-red;
+      &:focus {
+        border: 2px solid $color-black;
+        -webkit-box-shadow: inset 0 0 0 2px $color-red;
+        box-shadow: inset 0 0 0 2px $color-red;
+      }
     }
   }
 }


### PR DESCRIPTION
Also make the border color black on focus, even when there is an error.

Very small cleanup from previous story.

Note that browsers have their own formatting for the `required` error, which isn't dealt with at all. We are acting like we don't know anything about it.

## Screenshots

| before | after |
|--------|-------|
|  textarea border is black. focused error is yellow, red, and black.      |   textarea border is red. focused error is yellow, and black.    |
|  <img width="1466" alt="Screen Shot 2020-07-30 at 1 52 59 PM" src="https://user-images.githubusercontent.com/2454380/88957125-6b7ee280-d26c-11ea-884c-8f7088d965c1.png">   |  <img width="1466" alt="Screen Shot 2020-07-30 at 1 52 51 PM" src="https://user-images.githubusercontent.com/2454380/88957134-6e79d300-d26c-11ea-8e0e-bd20858ff29b.png">  |




