### PR TITLE
Remove login link on login page + remove TODO (and add test)

### DIFF
--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -366,6 +366,14 @@
             "index": "pypi",
             "version": "==0.3.15"
         },
+        "importlib-metadata": {
+            "hashes": [
+                "sha256:90bb658cdbbf6d1735b6341ce708fc7024a3e14e99ffdc5783edea9f9b077f83",
+                "sha256:dc15b2969b4ce36305c51eebe62d418ac7791e9a157911d58bfb1f9ccd8e2070"
+            ],
+            "markers": "python_version < '3.8'",
+            "version": "==1.7.0"
+        },
         "mccabe": {
             "hashes": [
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
@@ -470,6 +478,14 @@
                 "sha256:fe460b922ec15dd205595c9b5b99e2f056fd98ae8f9f56b888e7a17dc2b757e7"
             ],
             "version": "==1.4.1"
+        },
+        "zipp": {
+            "hashes": [
+                "sha256:aa36550ff0c0b7ef7fa639055d797116ee891440eac1a56f378e2d3179e0320b",
+                "sha256:c599e4d75c98f6798c509911d08a22e6c021d074469042177c8c86fb92eefd96"
+            ],
+            "markers": "python_version >= '3.6'",
+            "version": "==3.1.0"
         }
     }
 }

--- a/portal/templates/includes/nav_header.html
+++ b/portal/templates/includes/nav_header.html
@@ -5,7 +5,8 @@
     {% if user.is_authenticated %}
       <li><a href="{% url 'user_profile' user.id %}">{{ _("Your account") }}</a></li>
       <li><a href="{% url 'logout' %}">{% trans 'Log out' %}</a></li>
-    {% else %}
+    {% endif %}
+    {% if request.resolver_match.url_name != 'login' %}
       <li><a href="{% url 'login' %}">{% trans 'Log in' %}</a></li>
     {% endif %}
     <li>

--- a/profiles/templates/invitations/email/email_invite_message.html
+++ b/profiles/templates/invitations/email/email_invite_message.html
@@ -13,6 +13,6 @@
 <p>Bonjour,</p>
 <p>L’application mobile Alerte COVID fait partie des efforts importants déployés pour ralentir la propagation de COVID-19. Votre gestionnaire vous a autorisé à générer des clés Alerte COVID.</p>
 <h2>Votre invitation pour le Portail expire dans 24 heures</h2>
-<p><a href="{{ invite_url }}">Créez votre compte</a> pour pouvoir fournir des clés à usage unique aux patients ayant un diagnostic de COVID-19. Ces derniers pourront ensuite aviser de façon anonyme les autres personnes d’une exposition potentielle.  Merci pour tout le travail que vous faites pour nos communautés!</p>
+<p><a href="{{ invite_url }}">Créez votre compte</a> pour pouvoir fournir des clés à usage unique aux patients ayant un diagnostic de COVID-19. Ces derniers pourront ensuite aviser de façon anonyme les autres personnes d’une exposition potentielle.Merci pour tout le travail que vous faites pour nos communautés!</p>
 <p>L’équipe Alerte COVID</p>
 {% include 'includes/emails/footer.html' %}

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -112,6 +112,19 @@ class AdminUserTestCase(TestCase):
         session.save()
 
 
+class UnauthenticatedView(TestCase):
+    def test_login_page(self):
+        response = self.client.get(reverse("login"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<h1>Log in</h1>")
+        self.assertNotContains(response, '<a href="/en/login/">Log in</a>')
+
+    def test_privacy_page(self):
+        response = self.client.get(reverse("privacy"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<h1>Privacy</h1>")
+
+
 class RestrictedPageViews(TestCase):
     #  These should redirect us
     def test_code(self):

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -162,15 +162,14 @@ class InvitationView(Is2FAMixin, IsAdminMixin, FormView):
         subject_line = "{}{}".format(
             get_site_name(self.request), _(": Your portal account")
         )
-        invite.send_invitation(
-            self.request,
-            scheme=self.request.scheme,
-            http_host=current_site.domain,
-            subject_line=subject_line,
-        )
-        messages.success(
-            self.request, f"You’ve sent the invitation to “{invite.email}”", "invite"
-        )
+        if not settings.TESTING:
+            # Don't actually send the email during tests
+            invite.send_invitation(
+                self.request,
+                scheme=self.request.scheme,
+                http_host=current_site.domain,
+                subject_line=subject_line,
+            )
         self.request.session["invite_email"] = invite.email
         return super().form_valid(form)
 


### PR DESCRIPTION
This PR adds a couple of very small changes + some tests.

- Removes the login link on the login page: it's redundant and now I see it all the time since the landing page is removed
- Test for login page and privacy page: just to see that they are 200
- Remove TODO about adding 2 invites at once, closes #153 
- Adds a test for sending an invite (not just setting a session variable), and adds a test for sending double invites

We used to fail when sending two invites to the same email address, but no longer. Didn't have tests for it though.
