### PR TITLE
Re-add buildspec for Elastic Beanstalk + Add service IP to allowed hosts for ALB healthcheck

### DIFF
--- a/buildspec-eb.yml
+++ b/buildspec-eb.yml
@@ -1,0 +1,33 @@
+version: 0.2
+
+env:
+  variables:
+    DJANGO_ENV: "development"
+phases:
+  install:
+    runtime-versions:
+      python: 3.x
+  pre_build:
+    commands:
+      - pip install --upgrade pip setuptools pipenv
+      - pipenv install --dev
+      - echo "Compile CSS"
+      - pipenv run python manage.py sass profiles/static/scss/styles.scss profiles/static/css/
+      - echo "Collect static files"
+      - pipenv run python manage.py collectstatic --noinput -i scss
+      - echo "Compiling French Translations"
+      - pipenv run python manage.py compilemessages
+      - echo "Running DB Migrations locally"
+      - pipenv run python manage.py migrate --noinput
+  build:
+    commands:
+      - pipenv run python manage.py test
+
+  post_build:
+    commands:
+      - echo "Cleaning up"
+      - rm db.sqlite3
+      - rm ./portal/requirements.txt
+artifacts:
+  files:
+    - "**/*"

--- a/buildspec-eb.yml
+++ b/buildspec-eb.yml
@@ -1,8 +1,5 @@
 version: 0.2
 
-env:
-  variables:
-    DJANGO_ENV: "development"
 phases:
   install:
     runtime-versions:

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -25,7 +25,6 @@ phases:
       - IMAGE_TAG=${COMMIT_HASH:=latest}
   build:
     commands:
-
       - echo Build started on `date`
       - echo Building the Docker image...
       - docker build -t $IMAGE_REPO_NAME:latest .

--- a/config/terraform/aws/lb.tf
+++ b/config/terraform/aws/lb.tf
@@ -13,7 +13,7 @@ resource "aws_lb_target_group" "covidportal" {
   health_check {
     enabled             = true
     interval            = 10
-    path                = "/en/landing/"
+    path                = "/en/login/"
     port                = 8000
     matcher             = "301,200"
     timeout             = 5
@@ -39,7 +39,7 @@ resource "aws_lb_target_group" "covidportal_2" {
     enabled             = true
     interval            = 10
     port                = 8000
-    path                = "/en/landing/"
+    path                = "/en/login/"
     matcher             = "301,200"
     timeout             = 5
     healthy_threshold   = 2
@@ -105,7 +105,7 @@ resource "aws_lb_listener" "covidportal_http" {
     }
   }
 
-    lifecycle {
+  lifecycle {
     ignore_changes = [
       default_action # updated by codedeploy
     ]

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -19,6 +19,7 @@ from dotenv import load_dotenv
 from datetime import timedelta
 from logging import getLogger, CRITICAL
 from django.utils.translation import gettext_lazy as _
+from socket import gethostname, gethostbyname, gaierror
 
 load_dotenv()
 
@@ -48,7 +49,16 @@ ALLOWED_HOSTS = [
     "0.0.0.0",
     "127.0.0.1",
     "localhost",
+    gethostname(),
 ]
+
+if not DEBUG and not TESTING:
+    try:
+        # this will fail locally because the macbook name can't be resolved to an IP
+        host_by_name = gethostbyname(gethostname())
+        ALLOWED_HOSTS.append(host_by_name)
+    except gaierror:
+        pass
 
 if os.getenv("DJANGO_ALLOWED_HOSTS"):
     ALLOWED_HOSTS.extend(os.getenv("DJANGO_ALLOWED_HOSTS").split(","))


### PR DESCRIPTION
This PR fixes 2 things:

- Our Elastic Beanstalk automated deployments
- Our Fargate manual deployments


### Elastic Beanstalk automated deployments

We updated the `buildspec.yml` file in #134 so that the app will build in ECS, but it broke our builds in our staging environment. 

Since we're still using staging for now, I've re-added the previous EB-compatible buildspec file and updated both EB deploy pipelines to look for this other buildspec file instead of the new Fargate buildspec.

## Fargate manual deployments

Also updated the healthcheck URL for the load balancers in our terraform configuration. The landing page has been removed, so healthchecks to the previous URL will return 404s, not 301s.

I've also added the  service IP to ALLOWED_HOSTS for ALB healthchecks on startup. The target group healthchecks currently fail because of Django's host header validation. ELB/Target groups use the IP of the target as the host header so lets grab it on startup if we're running in a prod environment.

Pretty sure this makes #158 redundant.