### PR TITLE
Make sure the keygen limit is not global

### DIFF
--- a/covid_key/views.py
+++ b/covid_key/views.py
@@ -22,7 +22,8 @@ def code(request):
         return redirect("start")
 
     created_keys_count = COVIDKey.objects.filter(
-        created_at__gte=timezone.now() - timedelta(hours=24)
+        created_at__gte=timezone.now() - timedelta(hours=24),
+        created_by_id=request.user.id,
     ).count()
     if created_keys_count < settings.COVID_KEY_MAX_PER_USER_PER_DAY:
         return _generate_key(request)


### PR DESCRIPTION
https://trello.com/c/jnDfGmEY/253-bug-keygen-limit-is-global-not-local
The key throttle limit was global, instead of being per user. This PR fixes that.
It also adds a unit test to make sure it doesn't happen again.