### PR TITLE
[bugfixes] Redirect to /start if logged in + stop sending duplicate 2FA codes on account creation

### DIFF
--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -112,6 +112,21 @@ class AdminUserTestCase(TestCase):
         session.save()
 
 
+class RootView(AdminUserTestCase):
+    def setUp(self):
+        super().setUp(is_admin=True)
+
+    def test_not_authenticated_redirects_to_login(self):
+        response = self.client.get("/", follow=True)
+        self.assertRedirects(response, "/en/login/?next=/en/start/")
+
+    def test_authenticated_redirects_to_start(self):
+        self.client.login(username="test@test.com", password="testpassword")
+        self.login_2fa()
+        response = self.client.get("/", follow=True)
+        self.assertRedirects(response, "/en/start/")
+
+
 class UnauthenticatedView(TestCase):
     def test_login_page(self):
         response = self.client.get(reverse("login"))

--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -9,7 +9,7 @@ from . import forms
 
 
 urlpatterns = [
-    path("", RedirectView.as_view(pattern_name="login")),
+    path("", RedirectView.as_view(pattern_name="start")),
     path("invite/", views.InvitationView.as_view(), name="invite"),
     path("invite/list/", views.InvitationListView.as_view(), name="invitation_list"),
     path(

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -83,7 +83,6 @@ class SignUpView(FormView):
             password=form.cleaned_data.get("password1"),
         )
         login(self.request, user)
-        generate_2fa_code(user)
         return super(SignUpView, self).form_valid(form)
 
 


### PR DESCRIPTION
This PR:

- Redirects to "/start" from the root domain if the user is logged in (previously, it would always load the login page)
- Removes the duplicate SMS TFA code that would be sent on account creation

### Redirect to start page on root if already logged in

If logged in, redirect to start page. Else, redirect to login page.

### Remove explicit 2FA call after account created

Creating a new account triggers `update` in signals.py, which sends a 2FA SMS to the new phone number.
We were also explicitly creating an SMS to send at the end of user creation.
The result was that users would get 2 TFA codes on account creation, but only the second one was usable.

Removing the account-creation call from the view, leaving the signals.py one.
