### PR TITLE
Dont send SMS on user creation

### DIFF
--- a/profiles/signals.py
+++ b/profiles/signals.py
@@ -37,4 +37,3 @@ def update_2fa(sender, instance, created, **kwargs):
         sms_device = instance.notifysmsdevice_set.create()
         sms_device.number = instance.phone_number.as_e164
         sms_device.save()
-        sms_device.generate_challenge()

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -75,13 +75,13 @@ class SignUpView(FormView):
 
     def form_valid(self, form):
         form.save()
-        # messages.success(self.request, _("Account created successfully"))
         user = authenticate(
             request=self.request,
             username=form.cleaned_data.get("email"),
             password=form.cleaned_data.get("password1"),
         )
         login(self.request, user)
+        generate_2fa_code(user)
         return super(SignUpView, self).form_valid(form)
 
 


### PR DESCRIPTION
Send it in SignupForm after the user has been logged in.

https://trello.com/c/mH2vyhjX/285-bug-creating-a-user-through-the-django-admin-panel-sends-that-user-a-text