### PR TITLE
Found the Secret Sauce to Deployment - Removing mention of Lambda function

### DIFF
--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -104,12 +104,12 @@ jobs:
           docker tag base $PROD_ECR_REGISTRY:$GITHUB_SHA
           docker tag base $PROD_ECR_REGISTRY:latest
 
-#      - name: Push all containers to production Amazon ECR
-#        env:
-#          PROD_ECR_REGISTRY: ${{ secrets.PROD_ECR_REGISTRY }}
-#        run: |
-#          docker push $PROD_ECR_REGISTRY:$GITHUB_SHA
-#          docker push $PROD_ECR_REGISTRY:latest
+      - name: Push all containers to production Amazon ECR
+        env:
+          PROD_ECR_REGISTRY: ${{ secrets.PROD_ECR_REGISTRY }}
+        run: |
+          docker push $PROD_ECR_REGISTRY:$GITHUB_SHA
+          docker push $PROD_ECR_REGISTRY:latest
 
       - name: Logout of Production Amazon ECR
         if: always()

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -104,12 +104,12 @@ jobs:
           docker tag base $PROD_ECR_REGISTRY:$GITHUB_SHA
           docker tag base $PROD_ECR_REGISTRY:latest
 
-      - name: Push all containers to production Amazon ECR
-        env:
-          PROD_ECR_REGISTRY: ${{ secrets.PROD_ECR_REGISTRY }}
- #       run: |
- #         docker push $PROD_ECR_REGISTRY:$GITHUB_SHA
- #         docker push $PROD_ECR_REGISTRY:latest
+#      - name: Push all containers to production Amazon ECR
+#        env:
+#          PROD_ECR_REGISTRY: ${{ secrets.PROD_ECR_REGISTRY }}
+#        run: |
+#          docker push $PROD_ECR_REGISTRY:$GITHUB_SHA
+#          docker push $PROD_ECR_REGISTRY:latest
 
       - name: Logout of Production Amazon ECR
         if: always()

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -107,9 +107,9 @@ jobs:
       - name: Push all containers to production Amazon ECR
         env:
           PROD_ECR_REGISTRY: ${{ secrets.PROD_ECR_REGISTRY }}
-        run: |
-          docker push $PROD_ECR_REGISTRY:$GITHUB_SHA
-          docker push $PROD_ECR_REGISTRY:latest
+ #       run: |
+ #         docker push $PROD_ECR_REGISTRY:$GITHUB_SHA
+ #         docker push $PROD_ECR_REGISTRY:latest
 
       - name: Logout of Production Amazon ECR
         if: always()

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -2,7 +2,7 @@ name: Build and Push to Container Registries
 
 on:
   push:
-    branches: [main]
+    branches: [main, github_flow_fix]
 
 env:
   GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -2,7 +2,7 @@ name: Build and Push to Container Registries
 
 on:
   push:
-    branches: [main, github_flow_fix]
+    branches: [main]
 
 env:
   GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -10,7 +10,7 @@ env:
 
 jobs:
   deploy-portal-service:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/github_flow_fix' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Wait for container to be built and pushed

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -2,7 +2,7 @@ name: Deploy to Staging
 
 on:
   push:
-    branches: [main, github_flow_fix]
+    branches: [main]
 
 env:
   GITHUB_SHA: ${{ github.sha }}
@@ -10,7 +10,7 @@ env:
 
 jobs:
   deploy-portal-service:
-    if: github.ref == 'refs/heads/github_flow_fix' && github.event_name == 'push'
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Wait for container to be built and pushed

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -2,7 +2,7 @@ name: Deploy to Staging
 
 on:
   push:
-    branches: [main]
+    branches: [main, github_flow_fix]
 
 env:
   GITHUB_SHA: ${{ github.sha }}
@@ -58,8 +58,7 @@ jobs:
           CONTAINER_PORT=`jq '.containerDefinitions[0].portMappings[0].containerPort' task-definition-portal.json`
           CONTAINER_NAME=${{ steps.download-taskdef-portal.outputs.container_name }}
           TASKDEF_ARN=`jq -r '.taskDefinitionArn' task-definition-portal.json | cut -f 1-6 -d "/"`
-          LAMBDA='RetrievalValidateBeforeTraffic'
-          jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" --arg lambda "$LAMBDA" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port | .Hooks[0].BeforeAllowTraffic = $lambda ' config/infrastructure/aws/appspec-template.json > covid-alert-portal-appspec.json
+          jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port | ' config/infrastructure/aws/appspec-template.json > covid-alert-portal-appspec.json
       - name: Deploy image for Covid Alert Portal
         timeout-minutes: 10
         uses: aws-actions/amazon-ecs-deploy-task-definition@7218b9c

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -58,7 +58,7 @@ jobs:
           CONTAINER_PORT=`jq '.containerDefinitions[0].portMappings[0].containerPort' task-definition-portal.json`
           CONTAINER_NAME=${{ steps.download-taskdef-portal.outputs.container_name }}
           TASKDEF_ARN=`jq -r '.taskDefinitionArn' task-definition-portal.json | cut -f 1-6 -d "/"`
-          jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port | ' config/infrastructure/aws/appspec-template.json > covid-alert-portal-appspec.json
+          jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port' config/infrastructure/aws/appspec-template.json > covid-alert-portal-appspec.json
       - name: Deploy image for Covid Alert Portal
         timeout-minutes: 10
         uses: aws-actions/amazon-ecs-deploy-task-definition@7218b9c


### PR DESCRIPTION
Removing the dependency on the Lambda function from the GitHub deploy action.  The server team uses a Lambda function to test for a successful deployment while we do not. 
Tested these code changes on the github_flow_fix branch and was able to build and deploy to staging environment.  This should be the LAST change we need to make to get green checkmarks across the board on github actions on `main` branch.