### PR TITLE
Delete invitation of an user when deleting the user

### DIFF
--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -770,6 +770,24 @@ class DeleteView(AdminUserTestCase):
             ),
         )
 
+    def test_invitation_deleted(self):
+        self.login()
+        user_credentials = get_other_credentials()
+        Invitation.create(email=user_credentials.get("email"), inviter=self.user)
+        user = User.objects.create_user(**user_credentials)
+
+        # Delete the user with an existing invitation
+        response = self.client.post(reverse("user_delete", kwargs={"pk": user.id}))
+        self.assertRedirects(response, reverse("profiles"))
+
+        count = Invitation.objects.filter(email=user_credentials.get("email")).count()
+        self.assertEqual(count, 0)
+
+        # Try to delete the user without invitation
+        user = User.objects.create_user(**user_credentials)
+        response = self.client.post(reverse("user_delete", kwargs={"pk": user.id}))
+        self.assertRedirects(response, reverse("profiles"))
+
 
 class ProfileEditView(AdminUserTestCase):
     def test_edit_name(self):

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -342,6 +342,12 @@ class UserDeleteView(Is2FAMixin, ProvinceAdminDeleteMixin, DeleteView):
     context_object_name = "profile_user"
     success_url = reverse_lazy("profiles")
 
+    def delete(self, request, *args, **kwargs):
+        response = super().delete(request, *args, **kwargs)
+        # This wont crash if no object is returned from the filtered query
+        Invitation.objects.filter(email=self.object.email).delete()
+        return response
+
 
 def redirect_after_timed_out(request):
     messages.add_message(


### PR DESCRIPTION
Some fields are not editable even by managers, so managers delete a user then invite them again.
This PR delete all invitation tied to the email of the user being deleted, so Managers can invite them again.

https://trello.com/c/gd7qVgST/296-admins-should-be-able-to-send-invites-to-previously-deleted-accounts