### PR TITLE
Fix - Log remote IP in Easy Audit

### DIFF
--- a/portal/settings.py
+++ b/portal/settings.py
@@ -250,7 +250,7 @@ DJANGO_EASY_AUDIT_LOGGING_BACKEND = "portal.audit_backends.LoggerBackend"
 DJANGO_EASY_AUDIT_UNREGISTERED_URLS_EXTRA = [r"^/status/"]
 # If the header is set it must be available on the request or an Error will be thrown
 if is_prod and not TESTING:
-    DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER = "X-Forwarded-For"
+    DJANGO_EASY_AUDIT_REMOTE_ADDR_HEADER = "HTTP_X_FORWARDED_FOR"
 
 CORS_ALLOW_CREDENTIALS = False
 CORS_ORIGIN_WHITELIST = []


### PR DESCRIPTION
We had set the key to X-Forwarded-For which would have worked if Easy Audit used `request.headers` but it references `request.META` so the key needs to be changed to HTTP_X_FORWARDED_FOR similar to the Axes configuration.