### PR TITLE
Changing the default value of OTP_THROTTLE_FACTOR to 3

### DIFF
--- a/portal/settings.py
+++ b/portal/settings.py
@@ -239,6 +239,7 @@ OTP_NOTIFY_ENDPOINT = (
 OTP_NOTIFY_API_KEY = os.getenv("OTP_NOTIFY_API_KEY")
 OTP_NOTIFY_TEMPLATE_ID = os.getenv("OTP_NOTIFY_TEMPLATE_ID")
 OTP_NOTIFY_TOKEN_VALIDITY = 90
+OTP_EMAIL_THROTTLE_FACTOR = 3
 # When DEBUG is on, we display the code directly in the form, no need to send it
 if DEBUG:
     OTP_NOTIFY_NO_DELIVERY = True


### PR DESCRIPTION
https://trello.com/c/OogOgaQF/306-update-otp-throttle-factor
Changes the default value of `1` to `3` for the throttling factor (the waiting time between each failed attempts).