### PR TITLE
Fix the link for the Check invitations button

### DIFF
--- a/profiles/templates/invitations/templates/invite_complete.html
+++ b/profiles/templates/invitations/templates/invite_complete.html
@@ -11,6 +11,6 @@
   <p>{% blocktrans %}They will need to check their email and follow instructions to create their account{% endblocktrans %}</p>
   <div class="content-button">
     <a href="{% url 'invite' %}" role='button' draggable='false'>{% trans "Add another account" %}</a>
-    <a href="{% url 'profiles' %}" class="secondary" role='button' draggable='false'>{% trans "Check invitations" %}</a>
+    <a href="{% url 'invitation_list' %}" class="secondary" role='button' draggable='false'>{% trans "Check invitations" %}</a>
   </div>
 {% endblock %}


### PR DESCRIPTION
https://trello.com/c/h0JWnKoj/305-bug-fix-direction-of-check-invitations-button-after-adding-an-account
After sending an invitation, we are shown a "Check invitations" button.
The button was sending to the team list, this PR fixes that and correctly sends you to the invitation list now.