### PR TITLE
Fix Log Filter match patterns and threshold

### DIFF
--- a/config/terraform/aws/certificates.tf
+++ b/config/terraform/aws/certificates.tf
@@ -1,6 +1,6 @@
 resource "aws_acm_certificate" "covidportal_staging" {
-  domain_name               = var.route53_zone_name
-  subject_alternative_names = ["*.${var.route53_zone_name}"]
+  domain_name               = "covid-hcportal.cdssandbox.xyz"
+  subject_alternative_names = ["*.covid-hcportal.cdssandbox.xyz"]
   validation_method         = "DNS"
 
   tags = {
@@ -10,20 +10,5 @@ resource "aws_acm_certificate" "covidportal_staging" {
   lifecycle {
     create_before_destroy = true
   }
-}
-
-resource "aws_route53_record" "covidportal_staging_certificate_validation" {
-  zone_id = aws_route53_zone.covidportal.zone_id
-  name    = aws_acm_certificate.covidportal_staging.domain_validation_options.0.resource_record_name
-  type    = aws_acm_certificate.covidportal_staging.domain_validation_options.0.resource_record_type
-  records = [aws_acm_certificate.covidportal_staging.domain_validation_options.0.resource_record_value]
-  ttl     = 60
-}
-
-resource "aws_acm_certificate_validation" "covidportal" {
-  certificate_arn = aws_acm_certificate.covidportal_staging.arn
-  validation_record_fqdns = [
-    aws_route53_record.covidportal_staging_certificate_validation.fqdn
-  ]
 }
 

--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -55,7 +55,7 @@ resource "aws_cloudwatch_metric_alarm" "portal_memory_utilization_high" {
 
 resource "aws_cloudwatch_log_metric_filter" "five_hundred_response" {
   name           = "500Response"
-  pattern        = "\"HTTP/1.1 ?500 ?501 ?502 ?503 ?504 ?505 ?506 ?507 ?508 ?510 ?511\""
+  pattern        = "\"HTTP/1.1 5\""
   log_group_name = aws_cloudwatch_log_group.covidportal.name
 
   metric_transformation {
@@ -73,7 +73,7 @@ resource "aws_cloudwatch_metric_alarm" "five_hundred_response_warn" {
   namespace           = "covidportal"
   period              = "60"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "0"
   treat_missing_data  = "notBreaching"
   alarm_description   = "Covid Alert Portal - This metric monitors for an 5xx level response"
 
@@ -100,7 +100,7 @@ resource "aws_cloudwatch_metric_alarm" "application_error_warn" {
   namespace           = "covidportal"
   period              = "60"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "0"
   treat_missing_data  = "notBreaching"
   alarm_description   = "Covid Alert Portal - This metric monitors for an Application error"
 
@@ -140,7 +140,7 @@ resource "aws_cloudwatch_metric_alarm" "key_generation_warn" {
 
 resource "aws_cloudwatch_log_metric_filter" "site_change" {
   name           = "SiteTableChange"
-  pattern        = "\"CRUD model:sites.site\""
+  pattern        = "\"CRUD\" \"model:sites.site\""
   log_group_name = aws_cloudwatch_log_group.covidportal.name
 
   metric_transformation {
@@ -158,7 +158,7 @@ resource "aws_cloudwatch_metric_alarm" "site_change_warn" {
   namespace           = "covidportal"
   period              = "60"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "0"
   treat_missing_data  = "notBreaching"
   alarm_description   = "COVID Alert Portal - This metric monitors for any site table changes"
   alarm_actions       = [aws_sns_topic.alert_warning.arn]
@@ -210,7 +210,7 @@ resource "aws_cloudwatch_metric_alarm" "InviteLockoutWarn" {
   namespace           = "covidportal"
   period              = "60"
   statistic           = "Sum"
-  threshold           = "1"
+  threshold           = "0"
   treat_missing_data  = "notBreaching"
   alarm_description   = "COVID Alert Portal - This metric montiors for too many invitations by a user"
   alarm_actions       = [aws_sns_topic.alert_warning.arn]

--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -82,7 +82,7 @@ resource "aws_cloudwatch_metric_alarm" "five_hundred_response_warn" {
 
 resource "aws_cloudwatch_log_metric_filter" "application_error" {
   name           = "ApplicationError"
-  pattern        = "ERROR"
+  pattern        = "Error"
   log_group_name = aws_cloudwatch_log_group.covidportal.name
 
   metric_transformation {

--- a/config/terraform/aws/rds.tf
+++ b/config/terraform/aws/rds.tf
@@ -50,4 +50,10 @@ resource "aws_rds_cluster" "covidportal_server" {
     Name                  = "${var.rds_server_name}-cluster"
     (var.billing_tag_key) = var.billing_tag_value
   }
+
+  lifecycle {
+    ignore_changes = [
+      snapshot_identifier
+    ]
+  }
 }

--- a/config/terraform/aws/variables.auto.tfvars
+++ b/config/terraform/aws/variables.auto.tfvars
@@ -46,7 +46,7 @@ vpc_name       = "covidportal"
 rds_db_subnet_group_name = "staging-portal-db"
 
 # RDS Cluster
-rds_server_db_name = "staging_covid_portal"
+rds_server_db_name = "covid_portal"
 rds_server_name    = "staging-covidportal-db"
 rds_server_db_user = "postgres"
 # Value should come from a TF_VAR environment variable (e.g. set in a Github Secret)


### PR DESCRIPTION
For Alarms and Metrics
- Fix the match patterns for the HTML 5xx metric that triggers the 5xx Alarm.
- Fix the match patterns for the Site Table changes that triggers the Site Table Change Alarm
- Lower the threshold to '0' instead of '1' for HTML 5xx, Site Table Change, Invite Lockout, and Application Error so it fires after a single event.  Current logic is using GreaterThan so setting threshold at '1' did not have desired effect.

For Elastic Beanstalk Staging to Fargate Staging
- Removed autogeneration of tf.covid-hcportal.cdssandbox.xyz certs due to using higher level bootstrapped domain.
- Added lifecycle block to RDS Cluster resource so that it doesn't recreate the database from scratch after we removed the snapshot it was created from.  Aka don't trigger a rebuild because we changed the 'snapshot_identified' variable.