### PR TITLE
Assign default superusers to CDS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Default superusers are associated with CDS, not "Ontario"
+
 ## [1.5.1] - 2020-09-08
 
 ### Fixed

--- a/profiles/models.py
+++ b/profiles/models.py
@@ -50,11 +50,11 @@ class HealthcareUserManager(BaseUserManager):
         """
         Creates and saves a superuser with the given email, name and password.
         """
-        ontario = HealthcareProvince.objects.get(abbr="ON")
+        cds = HealthcareProvince.objects.get(abbr="CDS")
         user = self.create_user(
             email,
             name=name,
-            province=ontario,
+            province=cds,
             password=password,
             is_superuser=True,
             **kwargs,

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -277,7 +277,7 @@ class DjangoAdminPanelView(AdminUserTestCase):
     def test_user_is_blocked(self):
         other_credentials = get_other_credentials()
         other_user = User.objects.create_user(**other_credentials)
-        other_user.blocked_until = datetime.now() + timedelta(days=1)
+        other_user.blocked_until = timezone.now() + timedelta(days=1)
         other_user.is_active = True
         other_user.save()
 

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -81,6 +81,13 @@ class BannedPasswordValidatorTestCase(TestCase):
                 self.validator.validate(password)
 
 
+class DefaultSuperUserTestCase(TestCase):
+    def test_default_superuser_from_cds(self):
+        self.credentials = get_other_credentials(is_superuser=True)
+        self.user = User.objects.create_superuser(**self.credentials)
+        self.assertEqual(self.user.province.name, "Canadian Digital Service")
+
+
 class AdminUserTestCase(TestCase):
     def setUp(self, is_admin=False):
         self.credentials = get_credentials(is_admin=is_admin)


### PR DESCRIPTION
This PR does 2 things:

- Associates default superusers with the "CDS" province
- Quiets a warning we were getting in one of the tests

###  Superusers created through the command line are from CDS 

Previously, superusers would be assigned to "Ontario" by default.

This was obviously a hack, technically superusers can be from any province and still do what they need to.

However, it makes more sense to have them as part of CDS, because in practice that's who is getting superuser accounts.

This PR resolves #60.