### PR TITLE
Use base URL from the request in password reset emails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix password reset links running in non-production environments
 - Default superusers are associated with CDS, not "Ontario"
 
 ## [1.5.1] - 2020-09-08

--- a/portal/templates/registration/password_reset_email.html
+++ b/portal/templates/registration/password_reset_email.html
@@ -2,7 +2,7 @@
 Hello {{ user.name }},
 Change your password
 We received a request to change your password for the COVID Alert Portal.
-You can change your password now : {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+You can change your password now : {{ base_url }}{% url 'password_reset_confirm' uidb64=uid token=token %}
 If you did not ask to change your password, ignore this email.
 Thank you,
 
@@ -13,7 +13,7 @@ The COVID Alert team
 Bonjour {{ user.name }},
 Modification du mot de passe
 Nous avons reçu votre demande de modification de mot de passe pour le Portail Alerte COVID.
-Vous pouvez modifier votre mot de passe maintenant: {{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}
+Vous pouvez modifier votre mot de passe maintenant: {{ base_url }}{% url 'password_reset_confirm' uidb64=uid token=token %}
 Si vous n’avez pas demandé de modifier votre mot de passe, ignorez ce courriel.
 Merci,
 

--- a/portal/templates/registration/password_reset_email_html.html
+++ b/portal/templates/registration/password_reset_email_html.html
@@ -3,7 +3,7 @@
 <p>Hello {{ user.name }},</p>
 <p>Change your password</p>
 <p>We received a request to change your password for the COVID Alert Portal.</p>
-<p>You can <a href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}">change your password</a> now.</p>
+<p>You can <a href="{{ base_url }}{% url 'password_reset_confirm' uidb64=uid token=token %}">change your password</a> now.</p>
 <p>If you did not ask to change your password, ignore this email.</p>
 <p>Thank you,</p>
 <p>The COVID Alert team</p>
@@ -13,7 +13,7 @@
 <p>Bonjour {{ user.name }},</p>
 <p>Modification du mot de passe</p>
 <p>Nous avons reçu votre demande demodification de mot de passe pour le Portail Alerte COVID.</p>
-<p>Vous pouvez <a href="{{ protocol }}://{{ domain }}{% url 'password_reset_confirm' uidb64=uid token=token %}">modifier votre mot de passe</a> maintenant.</p>
+<p>Vous pouvez <a href="{{ base_url }}{% url 'password_reset_confirm' uidb64=uid token=token %}">modifier votre mot de passe</a> maintenant.</p>
 <p>Si vous n’avez pas demandé de modifier votre mot de passe, ignorez ce courriel.</p>
 <p>Merci,</p>
 <p>L’équipe Alerte COVID</p>

--- a/profiles/urls.py
+++ b/profiles/urls.py
@@ -1,6 +1,5 @@
 from django.urls import path, re_path
 from django.views.generic import RedirectView, TemplateView
-from django.contrib.auth.views import PasswordResetView
 from django_otp.views import LoginView
 from django.contrib.auth import views as login_views
 
@@ -56,7 +55,7 @@ urlpatterns = [
     ),
     path(
         "profiles/<uuid:pk>/edit/password",
-        views.HealthcareuserPasswordResetView.as_view(
+        views.HealthcarePasswordChangeView.as_view(
             form_class=forms.HealthcarePasswordEditForm,
             template_name=forms.HealthcarePasswordEditForm.template_name,
         ),
@@ -117,11 +116,6 @@ urlpatterns = [
     ),
 ]
 
-# The PasswordResetView doesn't have any html template by default
-PasswordResetView.html_email_template_name = (
-    "registration/password_reset_email_html.html"
-)
-
 # Django.contrib.auth urls have underscore in them, let's change that for dashes
 urlpatterns += [
     path("login/", login_views.LoginView.as_view(), name="login"),
@@ -143,7 +137,7 @@ urlpatterns += [
     ),
     path(
         "password-reset/",
-        PasswordResetView.as_view(form_class=forms.HealthcarePasswordResetForm),
+        views.HealthcarePasswordResetView.as_view(),
         name="password_reset",
     ),
     path(

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -3,7 +3,7 @@ from django.conf import settings
 from django.shortcuts import redirect, render
 from django.contrib.sites.shortcuts import get_current_site
 from django.contrib.auth import login, authenticate
-from django.contrib.auth.views import PasswordChangeView
+from django.contrib.auth.views import PasswordChangeView, PasswordResetView
 from django.utils.translation import gettext as _
 from django.views.generic import (
     CreateView,
@@ -41,6 +41,7 @@ from .forms import (
     SignupForm,
     Healthcare2FAForm,
     HealthcareInviteForm,
+    HealthcarePasswordResetForm,
     Resend2FACodeForm,
     YubikeyDeviceCreateForm,
     YubikeyVerifyForm,
@@ -338,7 +339,20 @@ class HealthcareUserEditView(Is2FAMixin, ProvinceAdminEditMixin, UpdateView):
         return reverse_lazy("user_profile", kwargs={"pk": self.kwargs.get("pk")})
 
 
-class HealthcareuserPasswordResetView(PasswordChangeView):
+class HealthcarePasswordResetView(PasswordResetView):
+    form_class = HealthcarePasswordResetForm
+    html_email_template_name = "registration/password_reset_email_html.html"
+
+    def post(self, *args, **kwargs):
+        base_url = self.request.build_absolute_uri("/")
+        self.extra_email_context = {
+            "base_url": base_url[:-1],  # remove the trailing slash
+        }
+
+        return super().post(*args, **kwargs)
+
+
+class HealthcarePasswordChangeView(PasswordChangeView):
     def get_success_url(self):
         return reverse_lazy("user_profile", kwargs={"pk": self.kwargs.get("pk")})
 


### PR DESCRIPTION
Instead of looking at the sites table for password resets, use the protocol and domain from the existing request, which is what the invitations library does.

Seems way more intuitive.

The reason for this change is that sending requests from localhost or from the Heroku PRs would go to "example.com", as this is the default site name. 

Source:
- https://github.com/bee-keeper/django-invitations/search?q=build_absolute_uri&unscoped_q=build_absolute_uri