### PR TITLE
Deploy and tag containers only if VERSION has changed

### DIFF
--- a/.github/workflows/build-push-container.yml
+++ b/.github/workflows/build-push-container.yml
@@ -3,6 +3,8 @@ name: Build and Push to Container Registries
 on:
   push:
     branches: [main]
+    paths:
+      - "VERSION"
 
 env:
   GITHUB_SHA: ${{ github.sha }}

--- a/.github/workflows/deploy-to-staging.yml
+++ b/.github/workflows/deploy-to-staging.yml
@@ -3,6 +3,8 @@ name: Deploy to Staging
 on:
   push:
     branches: [main]
+    paths:
+      - "VERSION"
 
 jobs:
   deploy-portal-service:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Only tag and deploy a container to Amazon ECS if the VERSION file has been changed
+
 ## [1.6.0] - 2020-09-15
 
 ### Fixed


### PR DESCRIPTION
Only deploy and tag containers to ECS if the VERSION file has been changed

https://trello.com/c/cp14mUAI/345-wip-push-to-container-registries-should-happen-when-there-is-a-change-to-version-file