### PR TITLE
Fix main nav layout on login page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Title Case the words in the phonetic alphabet
+- Fixed CSS for "logged-in" nav items for the login page
 
 ## [1.8.1] - 2020-09-21
 

--- a/profiles/static/scss/pages/_login.scss
+++ b/profiles/static/scss/pages/_login.scss
@@ -62,7 +62,7 @@
         margin-bottom: 0;
       }
 
-      .page--container {
+      > .page--container {
         max-width: unset;
         padding: 0;
       }


### PR DESCRIPTION
On the login page, we zeroed out all the max-width spacing so that we could have full-bleed columns, but when you are on the login page _and you are logged in_, the nav menu is touching the side of the screen, which is a total oversight.

By making our CSS rules more specific, we fix the layout glitch.

## Screenshots

| before | after |
|--------|-------|
|  the "main" nav elements break our column layout   |   the "main" nav elements are aligned with the logo and the rest of the content    |
|  <img width="1422" alt="Screen Shot 2020-09-21 at 3 34 16 PM" src="https://user-images.githubusercontent.com/2454380/93826850-1a6ce880-fc36-11ea-9690-24a08ab88bbd.png">    |  <img width="1422" alt="Screen Shot 2020-09-21 at 3 34 18 PM" src="https://user-images.githubusercontent.com/2454380/93826835-13de7100-fc36-11ea-8bc3-23fcaea9d156.png">   |

