### PR TITLE
Fix the login screen image on IE11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Title Case the words in the phonetic alphabet
 - Fixed CSS for "logged-in" nav items for the login page
+- Fixed CSS for login thank you message on IE11
 
 ## [1.8.1] - 2020-09-21
 

--- a/profiles/static/scss/pages/_login.scss
+++ b/profiles/static/scss/pages/_login.scss
@@ -30,10 +30,12 @@
       display: flex;
       color: white;
       background: $color-blue-button;
+      min-height: 85vh;
 
       > .ty {
         margin: auto;
         text-align: center;
+        height: 230px; /* set a literal height for ie11 */
 
         .ty__hand {
           margin-top: -50px;


### PR DESCRIPTION
The thank you hand breaks out of the top of the column without an explicit height when you're on IE11.

Also added a `min-height` to the blue column 


## Screenshot

### ie11 login page

| before | after |
|--------|-------|
|  "thank you" message breaks out of the column     |  "thank you" message is centred     |
|  <img width="1433" alt="Screen Shot 2020-09-22 at 3 30 14 PM" src="https://user-images.githubusercontent.com/2454380/93933491-c1618b00-fcef-11ea-9344-168d8f1fcee5.png">  |  <img width="1433" alt="Screen Shot 2020-09-22 at 3 29 59 PM" src="https://user-images.githubusercontent.com/2454380/93933503-c45c7b80-fcef-11ea-898a-d75d80bd2cd1.png">    |

### login page on hi-res screens

| before | after |
|--------|-------|
|  blue column looks dumb on big screens   |  blue column is more normal looking     |
| <img width="1433" alt="Screen Shot 2020-09-22 at 4 24 20 PM" src="https://user-images.githubusercontent.com/2454380/93933786-2b7a3000-fcf0-11ea-8014-f374d4a828d1.png">  | <img width="1433" alt="Screen Shot 2020-09-22 at 4 24 30 PM" src="https://user-images.githubusercontent.com/2454380/93933772-287f3f80-fcf0-11ea-8d54-d48accd4ae20.png">  |



