### PR TITLE
Only upload Prod containers when Version file is updated

### DIFF
--- a/.github/workflows/prod-build-push-container.yml
+++ b/.github/workflows/prod-build-push-container.yml
@@ -1,0 +1,85 @@
+name: Prod — Push container to ECR
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "VERSION"
+
+env:
+  ECR_REPOSITORY: covid-alert-portal-terraform
+  GITHUB_SHA: ${{ github.sha }}
+
+jobs:
+  push-prod:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for container to pass Django CI 3.6 Test
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-CI-tests-3_6
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: test (3.6)
+          ref: ${{ github.sha }}
+
+      - name: Wait for container to pass Django CI 3.7 Test
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-CI-tests-3_7
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: test (3.7)
+          ref: ${{ github.sha }}
+
+      - name: Wait for container to pass Django CI 3.8 Test
+        uses: fountainhead/action-wait-for-check@v1.0.0
+        id: wait-for-CI-tests-3_8
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          checkName: test (3.8)
+          ref: ${{ github.sha }}
+
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Read VERSION file
+        id: version
+        uses: juliangruber/read-file-action@v1
+        with:
+          path: ./VERSION
+
+      - name: Build Covid Portal
+        run: docker build -t base --build-arg GITHUB_SHA_ARG=$GITHUB_SHA .
+
+      - name: Configure Production AWS credentials
+        id: aws-production
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+          aws-region: ca-central-1
+
+      - name: Login to Production Amazon ECR
+        id: login-ecr-prod
+        uses: aws-actions/amazon-ecr-login@v1
+
+      - name: Tag Images for Production
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr-prod.outputs.registry }}
+          VERSION: ${{ steps.version.outputs.content }}
+        run: |
+          docker tag base $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+          docker tag base $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION
+          docker tag base $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Push all containers to Production Amazon ECR
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr-prod.outputs.registry }}
+          VERSION: ${{ steps.version.outputs.content }}
+        run: |
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION
+          docker push $ECR_REGISTRY/$ECR_REPOSITORY:latest
+
+      - name: Logout of Production Amazon ECR
+        if: always()
+        run: docker logout ${{ steps.login-ecr-prod.outputs.registry }}

--- a/.github/workflows/staging-build-push-container.yml
+++ b/.github/workflows/staging-build-push-container.yml
@@ -1,26 +1,15 @@
-name: Build and Push to Container Registries
+name: Staging — Push container to ECR
 
 on:
   push:
     branches: [main]
 
 env:
+  ECR_REPOSITORY: covid-alert-portal-terraform
   GITHUB_SHA: ${{ github.sha }}
-  BRANCH: ${{ github.ref }}
 
 jobs:
-  terraform-security-scan:
-    runs-on: ubuntu-latest
-    continue-on-error: false
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-      - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.0.1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  build-n-push:
-    needs: terraform-security-scan
+  push-staging:
     runs-on: ubuntu-latest
     steps:
       - name: Wait for container to pass Django CI 3.6 Test
@@ -59,7 +48,7 @@ jobs:
       - name: Build Covid Portal
         run: docker build -t base --build-arg GITHUB_SHA_ARG=$GITHUB_SHA .
 
-      - name: Configure AWS credentials
+      - name: Configure Staging AWS credentials
         id: aws-covid-portal
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -68,23 +57,21 @@ jobs:
           aws-region: ca-central-1
 
       - name: Login to Staging Amazon ECR
-        id: login-ecr-covid-portal
+        id: login-ecr-staging
         uses: aws-actions/amazon-ecr-login@v1
 
       - name: Tag Images for Staging
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr-covid-portal.outputs.registry }}
-          ECR_REPOSITORY: covid-alert-portal-terraform
+          ECR_REGISTRY: ${{ steps.login-ecr-staging.outputs.registry }}
           VERSION: ${{ steps.version.outputs.content }}
         run: |
           docker tag base $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
           docker tag base $ECR_REGISTRY/$ECR_REPOSITORY:$VERSION
           docker tag base $ECR_REGISTRY/$ECR_REPOSITORY:latest
 
-      - name: Push containers to Amazon ECR
+      - name: Push containers to Staging Amazon ECR
         env:
-          ECR_REGISTRY: ${{ steps.login-ecr-covid-portal.outputs.registry }}
-          ECR_REPOSITORY: covid-alert-portal-terraform
+          ECR_REGISTRY: ${{ steps.login-ecr-staging.outputs.registry }}
           VERSION: ${{ steps.version.outputs.content }}
         run: |
           docker push $ECR_REGISTRY/$ECR_REPOSITORY:$GITHUB_SHA
@@ -94,37 +81,3 @@ jobs:
       - name: Logout of Staging Amazon ECR
         if: always()
         run: docker logout ${{ steps.login-ecr-covid-portal.outputs.registry }}
-
-      - name: Configure Production AWS credentials
-        id: aws-production
-        uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ca-central-1
-
-      - name: Login to Production Amazon ECR
-        id: login-ecr-prod
-        uses: aws-actions/amazon-ecr-login@v1
-
-      - name: Tag Images for Production
-        env:
-          PROD_ECR_REGISTRY: ${{ secrets.PROD_ECR_REGISTRY }}
-          VERSION: ${{ steps.version.outputs.content }}
-        run: |
-          docker tag base $PROD_ECR_REGISTRY:$GITHUB_SHA
-          docker tag base $PROD_ECR_REGISTRY:$VERSION
-          docker tag base $PROD_ECR_REGISTRY:latest
-
-      - name: Push all containers to production Amazon ECR
-        env:
-          PROD_ECR_REGISTRY: ${{ secrets.PROD_ECR_REGISTRY }}
-          VERSION: ${{ steps.version.outputs.content }}
-        run: |
-          docker push $PROD_ECR_REGISTRY:$GITHUB_SHA
-          docker push $PROD_ECR_REGISTRY:$VERSION
-          docker push $PROD_ECR_REGISTRY:latest
-
-      - name: Logout of Production Amazon ECR
-        if: always()
-        run: docker logout ${{ steps.login-ecr-prod.outputs.registry }}

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -6,7 +6,6 @@ on:
 
 jobs:
   deploy-portal-service:
-    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - name: Wait for container to be built and pushed


### PR DESCRIPTION
This pull request changes our deployment action so that we only upload containers to production if the Version file is updated.

We used to have one action that would: 

- Run a terraform security check
- Build a container in the local workspace
- Sign in to Staging Amazon and push the container to the container registry
- Sign in to Prod Amazon and push the container to the container registry

But I've split it out into 3 actions.

1. Run terraform scan & build container in local workspace
2. Wait for 1, then sign in to Staging Amazon and push the container to the container registry
3. Wait for 1, then check if "Version" file updated. If so, sign in to Prod Amazon and push the container to the container registry