### PR TITLE
Align new wait with correct dependency

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -13,7 +13,7 @@ jobs:
         id: wait-for-build
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          checkName: build-n-push
+          checkName: push-staging
           ref: ${{ github.sha }}
 
       - name: Checkout


### PR DESCRIPTION
Rename await dependency in Deploy to Staging action to new version in Push to Staging.  Variable name was `build-n-push` and is now `push-staging`