### PR TITLE
Delete previous invites if no user account exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Allow resending invitations whenever no user account exists. Previously, an "accepted" invitation for a deleted user would prevent that user from being invited again.
+
 ## [1.8.2] - 2020-09-25
 
 ### Updated

--- a/profiles/forms.py
+++ b/profiles/forms.py
@@ -368,8 +368,11 @@ class HealthcareInviteForm(HealthcareBaseForm, InviteForm):
         self.fields["email"].label = _("Email address")
 
     def validate_invitation(self, email):
-        # Delete all non-accepted invitations for the same email, if they exist
-        Invitation.objects.filter(email__iexact=email, accepted=False).delete()
+        account_exists = HealthcareUser.objects.filter(email=email).count()
+        if not account_exists:
+            # If there is no user account, delete any prior invitations to this email
+            Invitation.objects.filter(email__iexact=email).delete()
+
         return super().validate_invitation(email)
 
     def clean_email(self):

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -580,6 +580,59 @@ class InviteFlow(AdminUserTestCase):
                 response, "<h1>Invitation sent to {}</h1>".format(self.invited_email)
             )
 
+    def test_sent_invite_again_if_accepted_invite_exists_and_user_account_exists(
+        self,
+    ):
+        """
+        Login and send a duplicate invite where another invite already exists
+        and there is a user account corresponding to the invited email address
+        """
+        other_credentials = get_other_credentials(is_admin=False)
+        other_user = User.objects.create_user(**other_credentials)
+        invite = Invitation.create(
+            other_credentials["email"],
+            inviter=self.user,
+            sent=timezone.now(),
+            accepted=True,
+        )
+
+        self.client.login(username="test@test.com", password="testpassword")
+        self.login_2fa()
+        response = self.client.post(
+            reverse("invite"), {"email": other_credentials["email"]}, follow=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "This e-mail address has already accepted an invite."
+        )
+
+    def test_sent_invite_again_if_accepted_invite_exists_but_no_user_account_exists(
+        self,
+    ):
+        """
+        Login and send a duplicate invite where another invite already exists
+        BUT there is NO user account corresponding to the invited email address
+        """
+        other_credentials = get_other_credentials(is_admin=False)
+        invite = Invitation.create(
+            other_credentials["email"],
+            inviter=self.user,
+            sent=timezone.now(),
+            accepted=True,
+        )
+
+        self.client.login(username="test@test.com", password="testpassword")
+        self.login_2fa()
+        response = self.client.post(
+            reverse("invite"), {"email": other_credentials["email"]}, follow=True
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(
+            response, "This e-mail address has already accepted an invite."
+        )
+
     def test_send_invitation_invalid_domain(self):
         self.login()
         domain = "example.com"

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -588,8 +588,8 @@ class InviteFlow(AdminUserTestCase):
         and there is a user account corresponding to the invited email address
         """
         other_credentials = get_other_credentials(is_admin=False)
-        other_user = User.objects.create_user(**other_credentials)
-        invite = Invitation.create(
+        User.objects.create_user(**other_credentials)
+        Invitation.create(
             other_credentials["email"],
             inviter=self.user,
             sent=timezone.now(),
@@ -615,7 +615,7 @@ class InviteFlow(AdminUserTestCase):
         BUT there is NO user account corresponding to the invited email address
         """
         other_credentials = get_other_credentials(is_admin=False)
-        invite = Invitation.create(
+        Invitation.create(
             other_credentials["email"],
             inviter=self.user,
             sent=timezone.now(),
@@ -630,7 +630,8 @@ class InviteFlow(AdminUserTestCase):
 
         self.assertEqual(response.status_code, 200)
         self.assertContains(
-            response, "This e-mail address has already accepted an invite."
+            response,
+            "<h1>Invitation sent to {}</h1>".format(other_credentials["email"]),
         )
 
     def test_send_invitation_invalid_domain(self):


### PR DESCRIPTION
Previously, we were allowing:

- invite user
- user would sign up (invite is marked "accepted")
- user is deleted
- user is re-invited
- invite fails because accepted invite already exists

We pretty much always want to be able to invite someone when there is no user account for that person, so this PR makes that change.