### PR TITLE
Remove duplicate preload link from <head> + remove outline style for maintenance page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Unreleased
 
 - Allow resending invitations whenever no user account exists. Previously, an "accepted" invitation for a deleted user would prevent that user from being invited again.
+- Remove duplicate "preconnect" link in HTML header
 
 ## [1.8.2] - 2020-09-25
 

--- a/config/terraform/aws/maintenance_mode/en.htm
+++ b/config/terraform/aws/maintenance_mode/en.htm
@@ -4,8 +4,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">     
     
 
-    <!-- Bootstrap -->
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
     <!-- Google fonts -->
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback">

--- a/config/terraform/aws/maintenance_mode/en.htm
+++ b/config/terraform/aws/maintenance_mode/en.htm
@@ -1,56 +1,39 @@
 <!DOCTYPE html>
 <!-- saved from url=(0071)https://staging.covid-hcportal.cdssandbox.xyz/en/login/?next=/en/start/ -->
-<html lang="en"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">     
-    
+<html lang="en">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Google fonts -->
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
-    <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback">
-    <link type="text/css" href="./normalize.css" rel="stylesheet">
-    <link type="text/css" href="./styles.css" rel="stylesheet">
-    <link rel="shortcut icon" type="image/png" href="./favicon.ico">
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback" />
+    <link type="text/css" href="./normalize.css" rel="stylesheet" />
+    <link type="text/css" href="./styles.css" rel="stylesheet" />
+    <link rel="shortcut icon" type="image/png" href="./favicon.ico" />
 
     <title>
-  
-  Site Unavailable
- — COVID Alert Portal</title>
+      Site Unavailable — COVID Alert Portal
+    </title>
   </head>
   <body>
-    
     <div class="container">
       <header>
         <div class="page--container">
           <div class="fip-container">
-            
+            <div class="canada-flag">
+              <img type="image/svg+xml" src="./sig-blk-en.svg" alt="Government of Canada" />
+            </div>
 
-<div class="canada-flag">
-    
-    
-        <img type="image/svg+xml" src="./sig-blk-en.svg" alt="Government of Canada">
-    
-</div>
-
-            
-            
-              
-
-<nav class="nav--header" aria-label="Language and account navigation">
-  <ul>
-    
-    <li>
-        
-        
-        
-
-        <h2 class="visually-hidden">Language selection</h2>
-        <a href="./fr.htm">Français</a>
-    </li>
-  </ul>
-</nav>
-
-            
+            <nav class="nav--header" aria-label="Language and account navigation">
+              <ul>
+                <li>
+                  <h2 class="visually-hidden">Language selection</h2>
+                  <a href="./fr.htm">Français</a>
+                </li>
+              </ul>
+            </nav>
           </div>
         </div>
         <div class="page--container">
@@ -58,51 +41,25 @@
         </div>
       </header>
       <main id="content">
-
-        
-
-<nav class="nav--main anonymous" aria-label="Product navigation">
-  <div class="page--container">
-   
-  </div>
-</nav>
-
+        <nav class="nav--main anonymous" aria-label="Product navigation">
+          <div class="page--container"></div>
+        </nav>
 
         <div class="page--container" id="page--content" tabindex="-1">
           <div class="content--container login">
-            
-  
-
-
-  
-
-
-
-
-  <h1>Try again later</h1>
-  <p>Something went wrong with the system</p>
-  <p>We need to fix the problem so you can generate keys.</p>
-
-
-
+            <h1>Try again later</h1>
+            <p>Something went wrong with the system</p>
+            <p>We need to fix the problem so you can generate keys.</p>
           </div>
         </div>
-
       </main>
 
-      
-
-
-<footer>
-    <div class="page--container">
-        <div class="footer-links">
+      <footer>
+        <div class="page--container">
+          <div class="footer-links"></div>
+          <div class="canada-wordmark"><img type="image/svg+xml" src="./wmms-blk.svg" alt="Symbol of the Government of Canada" /></div>
         </div>
-        <div class="canada-wordmark"><img type="image/svg+xml" src="./wmms-blk.svg" alt="Symbol of the Government of Canada"></div>
+      </footer>
     </div>
-</footer>
-
-
-    </div>
-  
-
-</body></html>
+  </body>
+</html>

--- a/config/terraform/aws/maintenance_mode/fr.htm
+++ b/config/terraform/aws/maintenance_mode/fr.htm
@@ -1,57 +1,39 @@
 <!DOCTYPE html>
 <!-- saved from url=(0055)https://staging.covid-hcportal.cdssandbox.xyz/fr/login/ -->
-<html lang="fr"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-     
-    
+<html lang="fr">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
     <!-- Google fonts -->
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
-    <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback">
-    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback">
-    <link type="text/css" href="./normalize.css" rel="stylesheet">
-    <link type="text/css" href="./styles.css" rel="stylesheet">
-    <link rel="shortcut icon" type="image/png" href="./favicon.ico">
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
+    <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback" />
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback" />
+    <link type="text/css" href="./normalize.css" rel="stylesheet" />
+    <link type="text/css" href="./styles.css" rel="stylesheet" />
+    <link rel="shortcut icon" type="image/png" href="./favicon.ico" />
 
     <title>
-  
-      Site indisponible
- — Portail Alerte COVID</title>
+      Site indisponible — Portail Alerte COVID
+    </title>
   </head>
   <body>
-    
     <div class="container">
       <header>
         <div class="page--container">
           <div class="fip-container">
-            
+            <div class="canada-flag">
+              <img type="image/svg+xml" src="./sig-blk-fr.svg" alt="Gouvernement du Canada" />
+            </div>
 
-<div class="canada-flag">
-    
-    
-        <img type="image/svg+xml" src="./sig-blk-fr.svg" alt="Gouvernement du Canada">
-    
-</div>
-
-            
-            
-              
-
-<nav class="nav--header" aria-label="Navigation de compte et changement de langue">
-  <ul>
-    
-    <li>
-        
-        
-        
-
-        <h2 class="visually-hidden">Choix de langue</h2>
-        <a href="en.htm">English</a>
-    </li>
-  </ul>
-</nav>
-
-            
+            <nav class="nav--header" aria-label="Navigation de compte et changement de langue">
+              <ul>
+                <li>
+                  <h2 class="visually-hidden">Choix de langue</h2>
+                  <a href="en.htm">English</a>
+                </li>
+              </ul>
+            </nav>
           </div>
         </div>
         <div class="page--container">
@@ -59,53 +41,25 @@
         </div>
       </header>
       <main id="content">
-
-        
-
-<nav class="nav--main anonymous" aria-label="Navigation du produit">
-  <div class="page--container">
-   
-  </div>
-</nav>
-
+        <nav class="nav--main anonymous" aria-label="Navigation du produit">
+          <div class="page--container"></div>
+        </nav>
 
         <div class="page--container" id="page--content" tabindex="-1">
           <div class="content--container login">
-            
-  
-
-
-  
-
-
-
-
-  <h1>Réessayer plus tard</h1>
-  <p>Un problème a eu lieu avec le serveur</p>
-  <p>Nous devons régler le problème pour que vous puissez générer des clés</p>
-
-  
-
-
+            <h1>Réessayer plus tard</h1>
+            <p>Un problème a eu lieu avec le serveur</p>
+            <p>Nous devons régler le problème pour que vous puissez générer des clés</p>
           </div>
         </div>
-
       </main>
 
-      
-
-
-<footer>
-    <div class="page--container">
-        <div class="footer-links">
+      <footer>
+        <div class="page--container">
+          <div class="footer-links"></div>
+          <div class="canada-wordmark"><img type="image/svg+xml" src="./wmms-blk.svg" alt="Symbole du gouvernement du Canada" /></div>
         </div>
-        <div class="canada-wordmark"><img type="image/svg+xml" src="./wmms-blk.svg" alt="Symbole du gouvernement du Canada"></div>
+      </footer>
     </div>
-</footer>
-
-
-    </div>
-
-  
-
-</body></html>
+  </body>
+</html>

--- a/config/terraform/aws/maintenance_mode/fr.htm
+++ b/config/terraform/aws/maintenance_mode/fr.htm
@@ -5,8 +5,6 @@
      
     
 
-    <!-- Bootstrap -->
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
     <!-- Google fonts -->
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback">

--- a/config/terraform/aws/maintenance_mode/normalize.css
+++ b/config/terraform/aws/maintenance_mode/normalize.css
@@ -7,17 +7,14 @@ body {
   margin: 0;
 }
 
-
 main {
   display: block;
 }
-
 
 h1 {
   font-size: 2em;
   margin: 0.67em 0;
 }
-
 
 a {
   background-color: transparent;
@@ -26,4 +23,3 @@ a {
 img {
   border-style: none;
 }
-

--- a/config/terraform/aws/maintenance_mode/styles.css
+++ b/config/terraform/aws/maintenance_mode/styles.css
@@ -76,6 +76,10 @@ h6,
   padding-right: 20px;
 }
 
+#page--content:focus {
+  outline: none;
+}
+
 main {
   padding-bottom: 60px;
 }

--- a/config/terraform/aws/maintenance_mode/styles.css
+++ b/config/terraform/aws/maintenance_mode/styles.css
@@ -32,14 +32,12 @@ ul {
 
 @media screen and (min-width: 21em) {
   p,
-.multiple-choice__item p,
-ol,
-ul {
+  .multiple-choice__item p,
+  ol,
+  ul {
     margin-bottom: 15px;
   }
 }
-
-
 
 ol,
 ul {
@@ -48,11 +46,10 @@ ul {
 
 @media screen and (min-width: 35.5em) {
   ol,
-ul {
+  ul {
     padding-left: 40px;
   }
 }
-
 
 a,
 a:visited,
@@ -78,7 +75,6 @@ h6,
   padding-left: 20px;
   padding-right: 20px;
 }
-
 
 main {
   padding-bottom: 60px;
@@ -128,7 +124,6 @@ main > div {
   border: 0 !important;
   white-space: nowrap !important;
 }
-
 
 footer {
   width: 100%;
@@ -206,11 +201,10 @@ header .fip-container li button {
 
 @media screen and (min-width: 35.5em) {
   header .fip-container li a,
-header .fip-container li button {
+  header .fip-container li button {
     margin: 0;
   }
 }
-
 
 header .canada-flag {
   height: auto;
@@ -238,8 +232,6 @@ header #site-name {
   margin: 20px 0;
   text-align: left;
 }
-
-
 
 nav ul {
   margin: 0;

--- a/portal/templates/base.html
+++ b/portal/templates/base.html
@@ -19,10 +19,8 @@
       {% endif %}
     {% endwith %}
 
-    <!-- Bootstrap -->
-    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
     <!-- Google fonts -->
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="">
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback" >
 


### PR DESCRIPTION
This PR

- removes the duplicated "preload" link in the `<head>` of our site
  - also removes it on the maintenance page
- adds a CSS rule so that there's no more focus outline around the content on the maintenance page
- formats the CSS files for the maintenance page
- formats the HTML files for the maintenance page

Very small changes in here but the diff looks really big because of all the reformatting.