### PR TITLE
Add throttle check on form submission and post

### DIFF
--- a/covid_key/views.py
+++ b/covid_key/views.py
@@ -32,7 +32,8 @@ class CodeView(Is2FAMixin, ThrottledMixin, TemplateView):
         token = request.user.api_key
         diagnosis_code = "0000000000"
         covid_key = None
-        if token:
+        self.throttle_limit_check()
+        if token and not self.throttled_active:
             try:
                 try:
                     r = requests.post(

--- a/portal/mixins.py
+++ b/portal/mixins.py
@@ -37,7 +37,7 @@ class ThrottledMixin:
         }
         count = self.throttled_model.objects.filter(**filter_kwargs).count()
         if count > self.throttled_limit:
-            self.throttled_active = True 
+            self.throttled_active = True
 
     def _check(self):
         if self.throttled_model is None:

--- a/portal/mixins.py
+++ b/portal/mixins.py
@@ -36,7 +36,7 @@ class ThrottledMixin:
             - timedelta(seconds=self.throttled_time_range),
         }
         count = self.throttled_model.objects.filter(**filter_kwargs).count()
-        if count > self.throttled_limit:
+        if count >= self.throttled_limit:
             self.throttled_active = True
 
     def _check(self):

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -262,7 +262,6 @@ class InvitationView(Is2FAMixin, IsAdminMixin, ThrottledMixin, FormView):
 
     def form_valid(self, form):
         # Pass user to invite, save the invite to the DB, and return it
-
         invite = form.save(user=self.request.user)
         if not settings.TESTING:
             # Don't actually send the email during tests

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -262,17 +262,16 @@ class InvitationView(Is2FAMixin, IsAdminMixin, ThrottledMixin, FormView):
 
     def form_valid(self, form):
         # Pass user to invite, save the invite to the DB, and return it
-        self.throttle_limit_check()
-        if not self.throttled_active:
-            invite = form.save(user=self.request.user)
-            if not settings.TESTING:
-                # Don't actually send the email during tests
-                invite.send_invitation(
-                    self.request,
-                    scheme=self.request.scheme,
-                    language=get_language(),
-                )
-            self.request.session["invite_email"] = invite.email
+
+        invite = form.save(user=self.request.user)
+        if not settings.TESTING:
+            # Don't actually send the email during tests
+            invite.send_invitation(
+                self.request,
+                scheme=self.request.scheme,
+                language=get_language(),
+            )
+        self.request.session["invite_email"] = invite.email
         return super().form_valid(form)
 
     def limit_reached(self):

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -262,15 +262,17 @@ class InvitationView(Is2FAMixin, IsAdminMixin, ThrottledMixin, FormView):
 
     def form_valid(self, form):
         # Pass user to invite, save the invite to the DB, and return it
-        invite = form.save(user=self.request.user)
-        if not settings.TESTING:
-            # Don't actually send the email during tests
-            invite.send_invitation(
-                self.request,
-                scheme=self.request.scheme,
-                language=get_language(),
-            )
-        self.request.session["invite_email"] = invite.email
+        self.throttle_limit_check()
+        if not self.throttled_active:
+            invite = form.save(user=self.request.user)
+            if not settings.TESTING:
+                # Don't actually send the email during tests
+                invite.send_invitation(
+                    self.request,
+                    scheme=self.request.scheme,
+                    language=get_language(),
+                )
+            self.request.session["invite_email"] = invite.email
         return super().form_valid(form)
 
     def limit_reached(self):


### PR DESCRIPTION
This PR fixes a bug where invitations and OTKs could potentially be generated after the throttle limit was hit.

For Invitations:
- On invite page render check to see if self.throttled_active is tripped.  If so render lockout page.

For OTKs:
- On page _post function check to see if self.throttled_active is tripped before trying to get a OTK from the server.  If tripped when page render runs return the lockout page.