### PR TITLE
ThrottleMixin uses `dispatch` method instead of `render_to_response`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Add custom error templates for common error states
 - Very small change to the phonetic alphabet
+- Application throttling works as expected, fixed the sequencing of operations
 
 ## [1.8.4] - 2020-09-30
 

--- a/portal/mixins.py
+++ b/portal/mixins.py
@@ -14,7 +14,7 @@ class ThrottledMixin:
     throttled_limit = None
     throttled_time_range = None
 
-    def render_to_response(self, context, **response_kwargs):
+    def dispatch(self, *args, **kwargs):
         self._check()
 
         filter_kwargs = {
@@ -26,7 +26,7 @@ class ThrottledMixin:
         if count >= self.throttled_limit:
             return self.limit_reached()
 
-        return super().render_to_response(context, **response_kwargs)
+        return super().dispatch(*args, **kwargs)
 
     def limit_reached(self):
         return render(self.request, "throttled/locked.html", status=403)


### PR DESCRIPTION
**Note: this PR closes #260**

***

Using mixins allows us to intercept the lifecyle methods of a given view.

The problem with our ThrottleMixin is that the "render" method comes too late in the lifecycle of the class view.

In our COVID key view, the "post" method is called every time before the "render_to_response" method runs. Therefore, a key is always being generated, even when the throttling succeeds and tells the user they can't have any more keys.

By changing to the "dispatch" method, it runs _before_ the "get" or "post" methods of the View classes, so if the throttling succeeds, a key is no longer being created.

Sources:
- https://docs.djangoproject.com/en/3.1/ref/class-based-views/base/#django.views.generic.base.View.dispatch
- https://docs.djangoproject.com/en/3.1/topics/class-based-views/mixins/