### PR TITLE
Remove record of past login attempts for newly created accounts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add custom error templates for common error states
 - Very small change to the phonetic alphabet
 - Application throttling works as expected, fixed the sequencing of operations
+- Remove prior login attempts for newly created accounts
 
 ## [1.8.4] - 2020-09-30
 

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -13,7 +13,12 @@ from datetime import datetime, timedelta
 from freezegun import freeze_time
 
 from .forms import SignupForm, HealthcarePhoneEditForm
-from .models import HealthcareProvince, HealthcareUser, AuthorizedDomain
+from .models import (
+    HealthcareProvince,
+    HealthcareUser,
+    AuthorizedDomain,
+    HealthcareFailedAccessAttempt,
+)
 from .validators import BannedPasswordValidator
 from .utils.invitation_adapter import user_signed_up
 
@@ -543,9 +548,14 @@ class SignupFlow(AdminUserTestCase):
             HTTP_USER_AGENT="test-browser",
         )
 
-        # Assert that a login attempt record exists
+        # Assert that a login attempt records exist
         self.assertTrue(
             AccessAttempt.objects.filter(username=self.new_user_data["email"]).first(),
+        )
+        self.assertTrue(
+            HealthcareFailedAccessAttempt.objects.filter(
+                username=self.new_user_data["email"]
+            ).first(),
         )
 
         url = reverse("invitations:accept-invite", args=[self.invite.key])
@@ -561,6 +571,11 @@ class SignupFlow(AdminUserTestCase):
         # Assert that no login attempt records exist
         self.assertIsNone(
             AccessAttempt.objects.filter(username=self.new_user_data["email"]).first(),
+        )
+        self.assertIsNone(
+            HealthcareFailedAccessAttempt.objects.filter(
+                username=self.new_user_data["email"]
+            ).first(),
         )
 
 

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -29,6 +29,7 @@ from otp_yubikey.models import RemoteYubikeyDevice
 
 from portal.mixins import ThrottledMixin, Is2FAMixin, IsAdminMixin
 from invitations.models import Invitation
+from axes.models import AccessAttempt
 
 from .utils import generate_2fa_code
 from .utils.invitation_adapter import user_signed_up
@@ -169,6 +170,10 @@ class SignUpView(FormView):
         user_signed_up.send(sender=user.__class__, request=self.request, user=user)
         login(self.request, user)
         generate_2fa_code(user)
+
+        # delete matching access attempts for this user
+        AccessAttempt.objects.filter(username=user.email).delete(),
+
         return super(SignUpView, self).form_valid(form)
 
 

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -33,7 +33,7 @@ from axes.models import AccessAttempt
 
 from .utils import generate_2fa_code
 from .utils.invitation_adapter import user_signed_up
-from .models import HealthcareUser
+from .models import HealthcareUser, HealthcareFailedAccessAttempt
 from .mixins import (
     ProvinceAdminViewMixin,
     ProvinceAdminEditMixin,
@@ -173,6 +173,7 @@ class SignUpView(FormView):
 
         # delete matching access attempts for this user
         AccessAttempt.objects.filter(username=user.email).delete(),
+        HealthcareFailedAccessAttempt.objects.filter(username=user.email).delete()
 
         return super(SignUpView, self).form_valid(form)
 


### PR DESCRIPTION
This is a pretty out there edge case, but we've seen it happen.

If someone thinks they have an account and they try to log in a number of times, those attempts will be logged.

If they are then invited to join, they will potentially be locked out of the system because they previously tried to log in without an account.

If someone is being invited to the system, they should never be immediately locked out, so this fixes that behaviour.