### PR TITLE
Fix login page layout for IE10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Very small change to the phonetic alphabet
 - Application throttling works as expected, fixed the sequencing of operations
 - Remove prior login attempts for newly created accounts
+- Fix the login page layout on IE11
 
 ## [1.8.4] - 2020-09-30
 

--- a/profiles/static/scss/pages/_login.scss
+++ b/profiles/static/scss/pages/_login.scss
@@ -17,6 +17,7 @@
       margin-bottom: $space-xxl;
       padding-right: $space-xl;
       padding-left: $space-md;
+      display: inline-block;
 
       max-width: calc(960px / 2);
       margin-left: auto;


### PR DESCRIPTION
Fixes the login page layout up to IE10. Because we're using a Flexbox layout on the login page, IE10 doesn't really know what do to with it. In particular, it loses the second column entirely and pushes the login column over to the side because it doesn't think there's anything there.

By setting a default `display: inline-block` value, IE moves the login back where it makes sense. Note that the second column is still missing but it's not necessary on this page so we don't mind if it doesn't show up.

I went through most of the other pages and they all look pretty good.

Source:
- https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Flexible_Box_Layout/Backwards_Compatibility_of_Flexbox#display_inline-block

## Screenshot 

| before | after |
|--------|-------|
|    <img width="1532" alt="Screen Shot 2020-10-05 at 4 47 45 PM" src="https://user-images.githubusercontent.com/2454380/95130908-3dfe5b80-072b-11eb-96f0-b37ed7107c17.png">  |    <img width="1532" alt="Screen Shot 2020-10-05 at 4 47 48 PM" src="https://user-images.githubusercontent.com/2454380/95130898-3a6ad480-072b-11eb-802e-e57a34d0e032.png">  |

