### PR TITLE
Maintenance Page CSS and IMG fixes

### DIFF
--- a/config/terraform/aws/maintenance_mode/en.htm
+++ b/config/terraform/aws/maintenance_mode/en.htm
@@ -9,9 +9,9 @@
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback" />
-    <link type="text/css" href="./normalize.css" rel="stylesheet" />
-    <link type="text/css" href="./styles.css" rel="stylesheet" />
-    <link rel="shortcut icon" type="image/png" href="./favicon.ico" />
+    <link type="text/css" href="https://staging.covid-hcportal.cdssandbox.xyz/normalize.css" rel="stylesheet" />
+    <link type="text/css" href="https://staging.covid-hcportal.cdssandbox.xyz/styles.css" rel="stylesheet" />
+    <link rel="shortcut icon" type="image/png" href="https://staging.covid-hcportal.cdssandbox.xyz/favicon.ico" />
 
     <title>
       Site Unavailable — COVID Alert Portal
@@ -23,7 +23,7 @@
         <div class="page--container">
           <div class="fip-container">
             <div class="canada-flag">
-              <img type="image/svg+xml" src="./sig-blk-en.svg" alt="Government of Canada" />
+              <img type="image/svg+xml" src="https://staging.covid-hcportal.cdssandbox.xyz/sig-blk-en.svg" alt="Government of Canada" />
             </div>
 
             <nav class="nav--header" aria-label="Language and account navigation">
@@ -57,7 +57,7 @@
       <footer>
         <div class="page--container">
           <div class="footer-links"></div>
-          <div class="canada-wordmark"><img type="image/svg+xml" src="./wmms-blk.svg" alt="Symbol of the Government of Canada" /></div>
+          <div class="canada-wordmark"><img type="image/svg+xml" src="https://staging.covid-hcportal.cdssandbox.xyz/wmms-blk.svg" alt="Symbol of the Government of Canada" /></div>
         </div>
       </footer>
     </div>

--- a/config/terraform/aws/maintenance_mode/fr.htm
+++ b/config/terraform/aws/maintenance_mode/fr.htm
@@ -9,9 +9,9 @@
     <link rel="preconnect" href="https://fonts.gstatic.com/" crossorigin="" />
     <link rel="preload" as="style" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback" />
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Lato:400,700%7CNoto+Sans:400,700&amp;display=fallback" />
-    <link type="text/css" href="./normalize.css" rel="stylesheet" />
-    <link type="text/css" href="./styles.css" rel="stylesheet" />
-    <link rel="shortcut icon" type="image/png" href="./favicon.ico" />
+    <link type="text/css" href="https://staging.covid-hcportal.cdssandbox.xyz/normalize.css" rel="stylesheet" />
+    <link type="text/css" href="https://staging.covid-hcportal.cdssandbox.xyz/styles.css" rel="stylesheet" />
+    <link rel="shortcut icon" type="image/png" href="https://staging.covid-hcportal.cdssandbox.xyz/favicon.ico" />
 
     <title>
       Site indisponible — Portail Alerte COVID
@@ -23,7 +23,7 @@
         <div class="page--container">
           <div class="fip-container">
             <div class="canada-flag">
-              <img type="image/svg+xml" src="./sig-blk-fr.svg" alt="Gouvernement du Canada" />
+              <img type="image/svg+xml" src="https://staging.covid-hcportal.cdssandbox.xyz/sig-blk-fr.svg" alt="Gouvernement du Canada" />
             </div>
 
             <nav class="nav--header" aria-label="Navigation de compte et changement de langue">
@@ -57,7 +57,7 @@
       <footer>
         <div class="page--container">
           <div class="footer-links"></div>
-          <div class="canada-wordmark"><img type="image/svg+xml" src="./wmms-blk.svg" alt="Symbole du gouvernement du Canada" /></div>
+          <div class="canada-wordmark"><img type="image/svg+xml" src="https://staging.covid-hcportal.cdssandbox.xyz/wmms-blk.svg" alt="Symbole du gouvernement du Canada" /></div>
         </div>
       </footer>
     </div>


### PR DESCRIPTION
Changing the CSS and Img tag ref's to static instead of relative.  Due to the way S3 and Cloudfront handle routing the original URL does not change when Cloudfront returns a redirect.  For example `/en/login` does not exist on S3/Cloudfront so it returns the default `en.htm` page however the url remains `/en/login`.  This breaks all of the relative paths in the htm file file.  By changing to static it will ensure that the CSS and Img's always render no matter what non-existant URL is passed in.

If there is a better solution I'm all ears!!  👂 