### PR TITLE
Redirect to login if no existing user on yubikey verification page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Content updates to the Quick Guide page
 - (Super)admins are no longer permitted to change other users' passwords
+- Redirect to the login page if yubikey verification page is visited before user is authenticated
 
 ## [1.9.1] - 2020-10-09
 

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -174,9 +174,13 @@ class RestrictedPageViews(TestCase):
         response = self.client.get(reverse("start"))
         self.assertRedirects(response, "/en/login/?next=/en/start/")
 
-    def test_signup(self):
-        response = self.client.get(reverse("signup"))
-        self.assertRedirects(response, "/en/invite/expired")
+    def test_2fa(self):
+        response = self.client.get(reverse("login-2fa"))
+        self.assertRedirects(response, "/en/login/?next=/en/login-2fa/")
+
+    def test_yubikey_verify(self):
+        response = self.client.get(reverse("yubikey_verify"))
+        self.assertRedirects(response, "/en/login/")
 
     def test_django_admin_panel(self):
         response = self.client.get(reverse("admin:index"))

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -57,8 +57,12 @@ class YubikeyVerifyView(FormView):
     success_url = reverse_lazy("start")
 
     def get(self, request, *args, **kwargs):
+        if not request.user.is_authenticated:
+            return redirect(reverse_lazy("login"))
+
         if request.user.is_verified():
             return redirect(reverse_lazy("start"))
+
         return super().get(request, *args, **kwargs)
 
     def get_form_kwargs(self):


### PR DESCRIPTION
We've seen a few 500 errors because of people visiting this page directly without having gone through the login first.

It expects a user object to exist at this point so if there isn't one, we should redirect back to the login page.

Note: no screenshots because this isn't a visual change.