### PR TITLE
Hide "Your account" link on 2FA page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Hide the "Your account" link on the 2FA page because people can't see/edit their account info yet
+
 ## [1.9.2] - 2020-10-14
 
 ### Updated

--- a/portal/templates/includes/nav_header.html
+++ b/portal/templates/includes/nav_header.html
@@ -3,7 +3,11 @@
 <nav class="nav--header" aria-label="{% trans 'Language and account navigation' %}">
   <ul>
     {% if user.is_authenticated %}
-      <li><a href="{% url 'user_profile' user.id %}">{{ _("Your account") }}</a></li>
+      {# "user.is_authenticated" means they have passed the initial login screen (email, password) #}
+      {# "user.is_verifed" means they have also entered a 2FA code #}
+      {% if user.is_verified %}
+        <li><a href="{% url 'user_profile' user.id %}">{{ _("Your account") }}</a></li>
+      {% endif %}
       <li><a href="{% url 'logout' %}">{% trans 'Log out' %}</a></li>
     {% elif request.resolver_match.url_name != 'login' %}
       <li><a href="{% url 'login' %}">{% trans 'Log in' %}</a></li>

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -330,7 +330,7 @@ class DjangoAdminPanelView(AdminUserTestCase):
 
 
 class AuthenticatedView(AdminUserTestCase):
-    def test_loginpage(self):
+    def test_login_page(self):
         #  Get the login page
         response = self.client.get(reverse("login"))
         self.assertEqual(response.status_code, 200)
@@ -340,6 +340,16 @@ class AuthenticatedView(AdminUserTestCase):
         #  Test logging in
         response = self.client.post("/en/login/", self.credentials, follow=True)
         self.assertTrue(response.context["user"].is_active)
+
+    def test_2fa_page(self):
+        self.login(login_2fa=False)
+
+        #  Get the 2fa page
+        response = self.client.get(reverse("login-2fa"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<h1>Enter your security code</h1>")
+        self.assertNotContains(response, "Your account")
+        self.assertContains(response, "Log out")
 
     def test_login_with_uppercased_email_and_whitespace(self):
         _credentials = {


### PR DESCRIPTION
We had a minor incident where
- someone had changed their phone number
- got the to 2FA page
- couldn't get the text message to their new number
- saw the "Your account" link and clicked it
- wasn't able to see it, ended up on 2fa page again

Basically, you can't see your account until after you've passed the 2FA screen, so we shouldn't have it visible until after people progress past that screen.