### PR TITLE
Improvements to the presentation of backup codes + tests

### DIFF
--- a/profiles/static/scss/pages/_2fa-codes.scss
+++ b/profiles/static/scss/pages/_2fa-codes.scss
@@ -1,0 +1,28 @@
+.static-codes {
+  display: inline-block;
+  border: 2px dashed $color-grey;
+  padding: $space-md calc(#{$space-xl} + #{$space-md});
+  margin: $space-md 0 $space-lg 0;
+  border-radius: 10px;
+  text-align: left;
+  position: relative;
+
+  ul {
+    font-family: monospace;
+    font-size: 1.2em;
+    padding-left: 0;
+    margin-bottom: 0;
+    letter-spacing: 0.05em;
+    list-style-type: none;
+
+    li {
+      &:not(:last-of-type) {
+        margin-bottom: $space-sm;
+      }
+
+      [aria-hidden="true"] span:last-of-type {
+        padding-left: $space-xs;
+      }
+    }
+  }
+}

--- a/profiles/static/scss/styles.scss
+++ b/profiles/static/scss/styles.scss
@@ -6,6 +6,7 @@
 @import "./_base";
 
 /* Page-specific styles */
+@import "./pages/_2fa-codes";
 @import "./pages/_login";
 @import "./pages/_number";
 

--- a/profiles/templates/profiles/2fa-codes.html
+++ b/profiles/templates/profiles/2fa-codes.html
@@ -7,13 +7,20 @@
   {% include  "includes/flash_messages.html" %}
   <h1>{% trans "Security Codes" %}</h1>
   <p>{% trans "Without a mobile phone, you will need to use these single-use security codes to access the portal." %}</p>
-  {% for security_code in security_code_list %}
-  <h2>{{ security_code.token }}</h2>
 
-  {% endfor %}
+  <div class="static-codes">
+    <ul>
+    {% for security_code in security_code_list %}
+      <li>
+        <span class="visually-hidden">{{ security_code.token|upper|join:" " }}</span>
+        <span aria-hidden="true"><span>{{ security_code.token|slice:":4" }}</span><span>{{ security_code.token|slice:"4:" }}</span></span>
+      </li>
+    {% endfor %}
+    </ul>
+  </div>
 
   <p>{% trans "Write down these single-use security codes on a piece of paper." %}</p>
   <p>{% trans "Make sure to get more security codes before you use up all of the ones listed here." %}</p>
-  
+  <div class="content-button"><a href="{% url 'start' %}" role='button' draggable='false'>{% trans "Visit portal" %}</a></div>
 
 {% endblock %}

--- a/profiles/tests.py
+++ b/profiles/tests.py
@@ -1267,3 +1267,72 @@ class ProfileEditView(AdminUserTestCase):
         self.assertEqual(response.status_code, 302)
         user = HealthcareUser.objects.get(pk=self.user.id)
         self.assertEqual(user.phone_number, number)
+
+
+from waffle.models import Switch
+from django_otp.plugins.otp_static.models import StaticDevice
+
+
+class SecurityCodeView(AdminUserTestCase):
+    def setUp(self):
+        super().setUp(is_admin=True)
+        Switch.objects.create(name="SECURITY_CODE", active=True)
+
+    def test_user_can_view_security_codes_row_on_account_page(self):
+        self.login()
+        response = self.client.get(reverse("user_profile", kwargs={"pk": self.user.id}))
+        self.assertEqual(response.status_code, 200)
+        ## no security codes link present
+        self.assertContains(response, '<a href="/en/profiles/security-codes">')
+
+    def test_user_can_generate_5_security_codes(self):
+        self.login()
+        response = self.client.get(reverse("security_code_list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<h1>Security Codes</h1>")
+
+        device = StaticDevice.objects.get(user__id=self.user.id)
+        self.assertEqual(len(device.token_set.all()), 5)
+
+    def test_old_security_codes_invalid_if_new_security_codes_generated(self):
+        self.login()
+        response = self.client.get(reverse("security_code_list"))
+        self.assertEqual(response.status_code, 200)
+
+        old_codes = [
+            t.token
+            for t in StaticDevice.objects.get(user__id=self.user.id).token_set.all()
+        ]
+
+        response = self.client.get(reverse("security_code_list"))
+        self.assertEqual(response.status_code, 200)
+        new_codes = [
+            t.token
+            for t in StaticDevice.objects.get(user__id=self.user.id).token_set.all()
+        ]
+
+        for code in old_codes:
+            self.assertNotIn(code, new_codes)
+
+    def test_user_codes_HTML(self):
+        self.login()
+        response = self.client.get(reverse("security_code_list"))
+        self.assertEqual(response.status_code, 200)
+        self.assertContains(response, "<h1>Security Codes</h1>")
+        device = StaticDevice.objects.get(user__id=self.user.id)
+
+        tokens = [t.token for t in device.token_set.all()]
+
+        for token in tokens:
+            self.assertContains(
+                response,
+                '<span class="visually-hidden">{}</span>'.format(
+                    " ".join(token.upper())
+                ),
+            )
+            self.assertContains(
+                response,
+                '<span aria-hidden="true"><span>{}</span><span>{}</span>'.format(
+                    token[:4], token[-4:]
+                ),
+            )


### PR DESCRIPTION
This PR changes the presentation of the codes on the "generate backup codes" page, after looking through how some other services implemented backup codes. Let's get into it.

A summary of the changes are:
- use a fixed-width font
- visually separate the code into 2 parts (4 chars and 4 chars)
- group them together more clearly in the interface
- put them in an HTML list
- put an "visually hidden" element that capitalizes the characters in the code and inserts spaces between each of the characters

 Later, when backup codes are submitted, we should force lowercase them and remove all whitespace.

## Screenshots

| before | after |
|--------|-------|
|  <img width="1401" alt="Screen Shot 2020-11-04 at 11 32 38 AM" src="https://user-images.githubusercontent.com/2454380/98138819-7cee1100-1e91-11eb-9a46-9615db990301.png">   |  <img width="1401" alt="Screen Shot 2020-11-04 at 11 32 11 AM" src="https://user-images.githubusercontent.com/2454380/98138829-7fe90180-1e91-11eb-8ba9-bada089382fd.png">  |



## Research  

*Note: this is all covered in [this document](https://docs.google.com/document/d/1Ui23pnezBUO-QZVII2zsaysXuz8pNQVHf2hiI4W0MPI/edit#)*.

### Google & Github

A lot of similarities here. Both Google and Github:
- use same-width fonts
- visually separate their codes in the middle
- using semantic HTML for their list of codes (in a 2-column layout) 
- allow you to print or download as a .txt file
- invalidate your old codes when you generate new ones
- let you see existing codes you've generated

Google's codes are 8 characters long, all digits. Github's are 10 characters long, alphanumeric. 

| Google | Github |
|--------|-------|
|   <img width="1509" alt="Screen Shot 2020-11-03 at 11 26 02 AM" src="https://user-images.githubusercontent.com/2454380/98140861-f2f37780-1e93-11eb-8300-fdc5304a4466.png">   |   <img width="1509" alt="Screen Shot 2020-11-03 at 11 35 30 AM" src="https://user-images.githubusercontent.com/2454380/98140855-f129b400-1e93-11eb-850e-206a978b55c3.png">  |

There are problems with the Voiceover implementation for both though. Google has a bunch of blank cells in their table (literally read as "blank"), and in Github's implementation the list items are miscounted and the bullet point in front of the codes is read as "black circle".

### A screen-reader optimized ID code on the Digital Marketplace

Digital Marketplace implementation example

The Digital Marketplace service IDs (eg, [this IBM product](https://www.digitalmarketplace.service.gov.uk/g-cloud/services/808368535412356)) are visually spaced out but when copy+pasted they show up as a continuous string. Also, voiceover reads them out as separate characters. 

![id](https://user-images.githubusercontent.com/2454380/98141188-554c7800-1e94-11eb-86f3-eeb578e0b724.gif)

The HTML implementation of this is one visually hidden ID and then an aria-hidden ID which is separated into blocks of 4.

<img width="1316" alt="Screen Shot 2020-11-03 at 4 14 23 PM" src="https://user-images.githubusercontent.com/2454380/98141227-639a9400-1e94-11eb-8426-cbd2ff31c0cc.png">

So we should separate the presentation of the code from the reading of the code if we want the most control over each format.

### Testing Voiceover

![image](https://user-images.githubusercontent.com/2454380/98141782-04894f00-1e95-11eb-802b-f7dd52baf72f.png)

Given the following 4 options (note: this was an actual code generated by our algorithm), Voiceover read each one like this ([watch the video](https://drive.google.com/file/d/1uTAZ6NokYGO-3YaYF9fOfjdkgLgJZgKu/view?usp=sharing)):

1. Pronounced all of the letters but read very quickly. The “a” and “e” were hard to distinguish
2. Read the 1st section as letters but tried to read the 2nd section as a word
3. Pronounced all of the letters individually, more clearly then the lowercase letters
4. Tried to read it as a word

Voiceover usually will read the codes out letter-by-letter, but it seems to get caught in some edge cases. For example, if there are no digits in the code AND there are vowels in the code, then it will treat it as a word. The best case of the following options was forcing the letters to uppercase.


### Final implementation 

Using the precedents established by Google and Github's implementations, let's:
- use a fixed-width font
- visually separate the code into 2 parts (4 chars and 4 chars)
- group them together more clearly in the interface
- put them in an HTML list

To improve the screen reader behaviour, let's:
- put an "visually hidden" element that capitalizes the characters in the code and inserts spaces between each of the characters

 Later, when backup codes are submitted, we should force lowercase them and remove all whitespace.

