### PR TITLE
Tune Service Availability Anomaly Alarm

### DIFF
--- a/config/terraform/aws/cloudwatch.tf
+++ b/config/terraform/aws/cloudwatch.tf
@@ -252,7 +252,7 @@ resource "aws_cloudwatch_metric_alarm" "response_time_warn" {
 
   metric_query {
     id          = "e1"
-    expression  = "ANOMALY_DETECTION_BAND(m1, 3)"
+    expression  = "ANOMALY_DETECTION_BAND(m1, 5)"
     label       = "Response Times (Expected)"
     return_data = "true"
   }

--- a/config/terraform/aws/rds.tf
+++ b/config/terraform/aws/rds.tf
@@ -40,6 +40,8 @@ resource "aws_rds_cluster" "covidportal_server" {
   preferred_backup_window   = "07:00-09:00"
   db_subnet_group_name      = aws_db_subnet_group.covidportal.name
   storage_encrypted         = true
+  #tfsec:ignore:AWS051
+  # KMS key is not explicitly defined but a default key is created
 
 
   vpc_security_group_ids = [


### PR DESCRIPTION
This PR increases the Standard Deviation on the Anomaly alarm from 3 to 5.  This increase brings the new alarm threshold from 450ms to roughly 700ms.