### PR TITLE
Change sorting of users under "Manage Team"

### DIFF
--- a/profiles/views.py
+++ b/profiles/views.py
@@ -362,9 +362,10 @@ class ProfilesView(Is2FAMixin, IsAdminMixin, ListView):
         if not self.request.user.is_superuser:
             queryset = queryset.filter(is_superuser=False)
 
+        # sorting rules: (a) current user on top, (b) then admins, (c) then staff by email address alphabetically
         return queryset.annotate(
             current_user_email=RawSQL("email = %s", (self.request.user.email,))
-        ).order_by("-current_user_email", "-is_admin")
+        ).order_by("-current_user_email", "-is_admin", "email")
 
 
 class UserProfileView(Is2FAMixin, ProvinceAdminViewMixin, DetailView):


### PR DESCRIPTION
Adding one more sorting rule — now there are 3.

Sorting rules:
1. Make sure current user is always on top
2. Make sure admins are always listed before staff
3. Sort remaining accounts by email address alphabetically

## Screenshots

| before | after |
|--------|-------|
| no consistent sorting of staff accounts   |  staff accounts sorted by email address     |
|  <img width="1481" alt="Screen Shot 2020-11-04 at 3 20 00 PM" src="https://user-images.githubusercontent.com/2454380/98163962-8ab38e80-1eb1-11eb-854e-a62991d73d38.png">   |  <img width="1481" alt="Screen Shot 2020-11-04 at 3 20 13 PM" src="https://user-images.githubusercontent.com/2454380/98163957-87200780-1eb1-11eb-8473-6cc413772776.png">   |

