### PR TITLE
Add missing policy additions for alert_ok

### DIFF
--- a/config/terraform/aws/rds.tf
+++ b/config/terraform/aws/rds.tf
@@ -22,6 +22,8 @@ resource "aws_rds_cluster_instance" "covidportal_server_instances" {
   instance_class               = var.rds_server_instance_class
   db_subnet_group_name         = aws_db_subnet_group.covidportal.name
   performance_insights_enabled = true
+  #tfsec:ignore:AWS053
+  # KMS key is not explicitly defined but a default key is created
 
   tags = {
     Name                  = "${var.rds_server_name}-instance"

--- a/config/terraform/aws/sns.tf
+++ b/config/terraform/aws/sns.tf
@@ -85,7 +85,8 @@ data "aws_iam_policy_document" "cloudwatch_events_sns_topic_policy" {
     }
 
     resources = [
-      aws_sns_topic.alert_warning.arn
+      aws_sns_topic.alert_warning.arn,
+      aws_sns_topic.alert_ok.arn
     ]
 
     principals {
@@ -102,7 +103,8 @@ data "aws_iam_policy_document" "cloudwatch_events_sns_topic_policy" {
     ]
 
     resources = [
-      aws_sns_topic.alert_warning.arn
+      aws_sns_topic.alert_warning.arn,
+      aws_sns_topic.alert_ok.arn
     ]
 
     principals {


### PR DESCRIPTION
After testing in staging an error was raised because CloudWatch did not have publish access to the SNS for alert_ok.
This PR adds the SNS alert_ok resource to the policy.