### PR TITLE
Remove spaces and lowercase submitted 2FA codes

### DIFF
--- a/backup_codes/templates/includes/codes.html
+++ b/backup_codes/templates/includes/codes.html
@@ -4,7 +4,7 @@
     {% if code %}
       <li>
         <span class="visually-hidden">{{ code.token|upper|join:" " }}</span>
-        <span aria-hidden="true"><span>{{ code.token|slice:":4" }}</span><span>{{ code.token|slice:"4:" }}</span></span>
+        <span aria-hidden="true"><span>{{ code.token|upper|slice:":4" }}</span><span>{{ code.token|upper|slice:"4:" }}</span></span>
       </li>
     {% else %}
       <li aria-hidden="true" class="empty">

--- a/backup_codes/tests.py
+++ b/backup_codes/tests.py
@@ -104,7 +104,7 @@ class BackupCodesView(AdminUserTestCase):
             self.assertContains(
                 response,
                 '<span aria-hidden="true"><span>{}</span><span>{}</span>'.format(
-                    token[:4], token[-4:]
+                    token[:4].upper(), token[-4:].upper()
                 ),
             )
 

--- a/backup_codes/tests.py
+++ b/backup_codes/tests.py
@@ -145,12 +145,9 @@ class BackupCodesLogin(AdminUserTestCase):
         self.client.post(reverse("backup_codes"), follow=True)
 
     def logout(self):
-        response = self.client.get("/", follow=True)
-        if response.context["user"].is_active:
-            self.client.get(reverse("logout"))
+        self.client.logout()
 
     def test_user_can_login_with_backup_code(self):
-
         self.login(login_2fa=False)
 
         #  Get the 2fa page
@@ -159,18 +156,53 @@ class BackupCodesLogin(AdminUserTestCase):
 
         # Get backup code
         static_device = self.user.staticdevice_set.first()
-        token = static_device.token_set.first()
+        token = static_device.token_set.first().token
 
         # Submit backup code
-        post_data = {"code": token.token}
-        response = self.client.post(
-            reverse("login_2fa"),
-            post_data,
-            follow=True,
-        )
+        response = self.client.post(reverse("login_2fa"), {"code": token}, follow=True)
 
         # Check if we are now verified
-        self.assertTrue(response.context["user"].is_verified)
+        self.assertTrue(response.context["user"].is_verified())
+
+    def test_user_can_login_with_backup_code_case_insensitive(self):
+        self.login(login_2fa=False)
+
+        #  Get the 2fa page
+        response = self.client.get(reverse("login_2fa"))
+        self.assertEqual(response.status_code, 200)
+
+        # Get backup code
+        static_device = self.user.staticdevice_set.first()
+        token = static_device.token_set.first().token
+
+        # uppercase backup code
+        token = token.upper()
+
+        # Submit backup code
+        response = self.client.post(reverse("login_2fa"), {"code": token}, follow=True)
+
+        # Check if we are now verified
+        self.assertTrue(response.context["user"].is_verified())
+
+    def test_user_can_login_with_backup_code_whitespace(self):
+        self.login(login_2fa=False)
+
+        #  Get the 2fa page
+        response = self.client.get(reverse("login_2fa"))
+        self.assertEqual(response.status_code, 200)
+
+        # Get backup code
+        static_device = self.user.staticdevice_set.first()
+        token = static_device.token_set.first().token
+
+        # add leading and trailing whitespace, and a space in the middle
+        token = " {} {} ".format(token[:4], token[4:])
+
+        # Submit backup code
+        response = self.client.post(reverse("login_2fa"), {"code": token}, follow=True)
+
+        # Check if we are now verified
+        self.assertTrue(response.context["user"].is_verified())
 
     def test_user_can_login_with_sms_code(self):
         self.login(login_2fa=False)

--- a/profiles/forms.py
+++ b/profiles/forms.py
@@ -124,6 +124,13 @@ class Healthcare2FAForm(HealthcareBaseForm):
     )
     code.error_messages["required"] = validation_messages["code"]["required"]
 
+    # lowercase and remove whitespace from codes entered into the 2fa form
+    def clean_code(self):
+        # lowercase
+        code = self.cleaned_data["code"].lower()
+        # remove whitespace
+        return "".join(code.split(" "))
+
 
 class HealthcareBaseEditForm(HealthcareBaseForm, forms.ModelForm):
     template_name = "profiles/edit.html"


### PR DESCRIPTION
We display codes in uppercase and with a space in the middle, so that they are easier to copy and remember is the idea.

However, we only accept lowercased codes without spaces in between them.

This PR introduces a method that strips whitespace and lowercases all values submitted through the 2FA form.

## gif

Here's a gif of me logging in with a backup code that I've added uppercase chars to and extra spaces.


![Screen Recording 2020-11-17 at 3 56 02 PM](https://user-images.githubusercontent.com/2454380/99452106-20f3a580-28f1-11eb-90c3-a61cd6c31fd9.gif)
