### PR TITLE
Remove h3s, smaller h2s

### DIFF
--- a/about/templates/about/3_one_time_keys.html
+++ b/about/templates/about/3_one_time_keys.html
@@ -18,7 +18,7 @@
     <h2>{% trans "Before generating a key" %}</h2>
     <p>{% trans "You’ll confirm that the patient should get a key, and that they’re ready to enter or record it. The portal will guide you each time you need to do this." %}</p>
 
-    <h3>{% trans "Only generate a key if you intend to give it to a patient" %}</h3>
+    <h2>{% trans "Only generate a key if you intend to give it to a patient" %}</h2>
     <p>{% trans "This condition is part of our terms of use, so that we can keep stats accurate. We use the stats to improve COVID Alert." %}</p>
 
     <div class="content-next-link">

--- a/about/templates/about/4_give_a_key.html
+++ b/about/templates/about/4_give_a_key.html
@@ -20,7 +20,7 @@
         {% include "includes/big-code.html" %}
     {% endwith %}
 
-    <h3>{% trans "The app guides the patient through the next steps" %}</h3>
+    <h2>{% trans "The app guides the patient through the next steps" %}</h2>
     <p>{% trans "First the patient enters the key. Then the app guides them through the steps to notify people of possible exposure." %}
 
     {% url 'about:help_patient_enter_key' as help_url %}

--- a/about/templates/about/6_admin_accounts.html
+++ b/about/templates/about/6_admin_accounts.html
@@ -21,9 +21,5 @@
       <li>{% trans "Delete portal accounts." %}</li>
       <li>{% trans "Give security codes to healthcare workers who are locked out of the portal." %}</li>
     </ul>
-
-    <div class="content-next-link">
-      <a href="{% url 'support' %}" class="chevron-right">{% trans "Next:" %} {% trans "Support" %}</a>
-    </div>
   </div>
 {% endblock %}

--- a/profiles/static/scss/_base.scss
+++ b/profiles/static/scss/_base.scss
@@ -109,6 +109,20 @@ h6,
   font-weight: 600;
 }
 
+h1 {
+  font-size: 2.075em;
+}
+
+h2 {
+  font-size: 1.44em;
+}
+
+h3,
+h4,
+h5 {
+  font-size: 1.2em;
+}
+
 %page-container {
   max-width: 960px;
   margin: 0 auto;

--- a/profiles/templates/profiles/support.html
+++ b/profiles/templates/profiles/support.html
@@ -10,7 +10,7 @@
     <h2>{% trans "If you cannot log in to the portal" %}</h2>
     <p>{% trans "Ask your administrator for a security code." %}</p>
 
-    <h3>{% trans "If the portal is down" %}</h3>
+    <h2>{% trans "If the portal is down" %}</h2>
     <p>{% trans "Follow local procedures for patients who need keys." %}</p>
     <p>{% trans "Public health authorities must determine what to do for:" %}</p>
     <ul>
@@ -18,13 +18,13 @@
       <li>{% trans "System-wide portal outages." %}</li>
     </ul>
 
-    <h3>{% trans "For any other help with the portal" %}</h3>
+    <h2>{% trans "For any other help with the portal" %}</h2>
     {% url 'contact:index' as contact_url %}
     {% blocktrans %}
         <p><a href="{{ contact_url }}">Contact us</a>.</p>
     {% endblocktrans %}
 
-    <h3>{% trans "For help with the app" %}</h3>
+    <h2>{% trans "For help with the app" %}</h2>
     <p>{% trans "Patients can get support by:" %}</p>
     <ul>
       <li>{% trans "Phone:" %} 1-833-784-4397</li>


### PR DESCRIPTION
# Summary

This PR 
- removes the h3s we were using on the about pages
- removes the "next" link to the support page
- resizes some of the headings
 
I spent a lot more time on this than the number of commits would imply. Basically, I was on [type-scale.com](https://type-scale.com/) playing with different values and trying them out. In the end I went with [Minor Third at a base size of 20.8px](https://type-scale.com/?size=20.8&scale=1.200&text=A%20Visual%20Type%20Scale&font=Poppins&fontweight=400&bodyfont=body_font_default&bodyfontweight=400&lineheight=1.75&backgroundcolor=%23ffffff&fontcolor=%23000000&preview=false).

Since we don't really want to use h3s, I focused on the h1s and h2s — basically I was looking for a subtle change rather than a jarring one. In the end, the h1 is a tiny bit larger, the h2s are a lot smaller and h3s will be very small. 

## Screenshots

Used the Support page for the screenshot because it has a lot of text on it.

Before, we had h1s, h2s, h3s, leading to lots of font sizes. Now we just have h1s and h2s, but they are closer to the text size (although larger than the old h3s were). I think it looks better, but I spent too long on this story and maybe it looks the same.


| before | after |
|--------|-------|
| ![healthcare-portal herokuapp com_en_support_](https://user-images.githubusercontent.com/2454380/102367033-4f63af80-3f87-11eb-9c59-c9f2209dd1ba.png)      |   ![127 0 0 1_8000_en_support_ (1)](https://user-images.githubusercontent.com/2454380/102367365-aff2ec80-3f87-11eb-945e-b1a48142a34d.png))   |






