### PR TITLE
Fix slack notifications for staging environment

### DIFF
--- a/config/terraform/aws/lambda/lambda_notify_slack.js
+++ b/config/terraform/aws/lambda/lambda_notify_slack.js
@@ -13,7 +13,7 @@ function getMessage(message) {
 exports.handler = function(event, context) {
 
     var postData = {
-        "channel": "#exposure-healthcare-dev",
+        "channel": "#en-healthcare-dev",
         "username": "COVID Alert Portal Notifier",
         "text": "*Staging Environment*",
         "icon_emoji": ":loudspeaker:"


### PR DESCRIPTION
# Summary

The slack channel name changed over the holidays and our notifications stopped being sent. 

Updating to use the new name will fix this.


## Test instructions

This is one of those "test it by merging it" type PRs. ^.^