### PR TITLE
Update Github Actions to use newer versions

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
       - uses: dschep/install-pipenv-action@v1

--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -42,7 +42,7 @@ jobs:
           echo "##[set-output name=container_name;]$(jq -r '.containerDefinitions[0].name' task-definition-portal.json)"
       - name: Render image for portal service
         id: taskdef-portal
-        uses: aws-actions/amazon-ecs-render-task-definition@9666dc9
+        uses: aws-actions/amazon-ecs-render-task-definition@v1
         with:
           task-definition: task-definition-portal.json
           container-name: ${{ steps.download-taskdef-portal.outputs.container_name }}
@@ -56,7 +56,7 @@ jobs:
           jq  --argjson port "$CONTAINER_PORT" --arg cname "$CONTAINER_NAME" --arg taskdefarn "$TASKDEF_ARN" '.Resources[0].TargetService.Properties.TaskDefinition = $taskdefarn | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerName = $cname | .Resources[0].TargetService.Properties.LoadBalancerInfo.ContainerPort = $port' config/infrastructure/aws/appspec-template.json > covid-alert-portal-appspec.json
       - name: Deploy image for Covid Alert Portal
         timeout-minutes: 10
-        uses: aws-actions/amazon-ecs-deploy-task-definition@7218b9c
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v1
         with:
           task-definition: ${{ steps.taskdef-portal.outputs.task-definition }}
           service: covid-portal_staging


### PR DESCRIPTION
In particular, we're not allowed to use short SHA's anymore to reference particular actions, so this change is necessary before Feb 15.

Shouldn't affect anything: deploys should continue to work as normal.
