### PR TITLE
Enable link from Confirmation screen to generate a new poster

### DIFF
--- a/register/templates/register/confirmation.html
+++ b/register/templates/register/confirmation.html
@@ -27,7 +27,7 @@
   <p><a href="">Please see our FAQs for further advice for businesses and organizations</a></p>
 
   <div class="content-button">
-      <a href="{% url 'register:start' %}" role='button' draggable='false'>{% trans "Generate different poster" %}</a>
+      <a href="{% url 'register:location_step' pk=pk step='category' %}" role='button' draggable='false'>{% trans "Generate different poster" %}</a>
       <a href="{% url 'register:start' %}" role='button' draggable='false' class="secondary">{% trans "I am finished" %}</a>
   </div>
 

--- a/register/tests.py
+++ b/register/tests.py
@@ -50,7 +50,11 @@ class RegisterView(TestCase):
         session["registrant_email"] = email
         session.save()
 
-        response = self.client.get(reverse("register:confirmation"))
+        r = Registrant.objects.create(email=email)
+
+        response = self.client.get(
+            reverse("register:confirmation", kwargs={"pk": r.pk})
+        )
         self.assertEqual(response.status_code, 200)
         self.assertContains(
             response,

--- a/register/urls.py
+++ b/register/urls.py
@@ -34,7 +34,7 @@ urlpatterns = [
     ),
     path("<uuid:pk>/location/", location_wizard, name="location"),
     path(
-        "confirmation",
+        "<uuid:pk>/confirmation",
         views.RegisterConfirmationPageView.as_view(),
         name="confirmation",
     ),

--- a/register/views.py
+++ b/register/views.py
@@ -1,7 +1,6 @@
 from django.views.generic import TemplateView, FormView
 from django.views.generic.edit import UpdateView
 from django.urls import reverse_lazy, reverse
-from django.shortcuts import render
 
 from waffle.mixins import WaffleSwitchMixin
 
@@ -81,7 +80,6 @@ class LocationWizard(NamedUrlSessionWizardView):
     def done(self, form_list, form_dict, **kwargs):
         forms = [form.cleaned_data for form in form_list]
         location = dict(ChainMap(*forms))
-        registrant = Registrant.objects.get(id=self.kwargs.get("pk"))
 
         Location.objects.create(
             category=location["category"],

--- a/register/views.py
+++ b/register/views.py
@@ -10,6 +10,7 @@ from .forms import EmailForm, RegistrantNameForm
 from collections import ChainMap
 
 from formtools.wizard.views import NamedUrlSessionWizardView
+from django.http import HttpResponseRedirect
 
 
 class RegistrantEmailView(WaffleSwitchMixin, FormView):
@@ -82,7 +83,7 @@ class LocationWizard(NamedUrlSessionWizardView):
         location = dict(ChainMap(*forms))
         registrant = Registrant.objects.get(id=self.kwargs.get("pk"))
 
-        Location.objects.get_or_create(
+        Location.objects.create(
             category=location["category"],
             name=location["name"],
             address=location["address"],
@@ -94,13 +95,8 @@ class LocationWizard(NamedUrlSessionWizardView):
             contact_phone=location["contact_phone"],
         )
 
-        return render(
-            self.request,
-            "register/confirmation.html",
-            {
-                "registrant": registrant,
-                "form_data": location,
-            },
+        return HttpResponseRedirect(
+            reverse("register:confirmation", kwargs={"pk": self.kwargs.get("pk")})
         )
 
 


### PR DESCRIPTION
# Summary | Résumé

Enables the link on the Confirmation screen to "Generate a different poster" (previously was just linking back to the Start.

Also includes a minor rendering change for the Confirmation screen - previously it was rendering the confirmation from the POST route after submitting from the Summary. This adds a redirect to a confirmation-specific GET route.

## To test
- Start a new registration
- On the final Confirmation screen, click "Generate a different poster" and you will be taken to the Category step (instead of Start) 
