### PR TITLE
security: remove ingress and egress for default security group

### DIFF
--- a/config/terraform/aws/networking.tf
+++ b/config/terraform/aws/networking.tf
@@ -234,6 +234,10 @@ resource "aws_route_table_association" "covidportal_private_route" {
 # AWS Security Groups
 ###
 
+resource "aws_default_security_group" "default" {
+  vpc_id = aws_vpc.covidportal.id
+}
+
 resource "aws_security_group" "covidportal" {
   name        = "covidportal"
   description = "Ingress - Covid Portal"


### PR DESCRIPTION
This PR removes the default ingress and egress rules on the default security group for the VPC by adopting it into TF management. AWS recommends having no ingress or egress rules on the default group. As nothing should be using the default security group, this should have no impact.