### PR TITLE
Removed broken migration dependency

### DIFF
--- a/outbreaks/migrations/0001_initial.py
+++ b/outbreaks/migrations/0001_initial.py
@@ -12,7 +12,7 @@ class Migration(migrations.Migration):
 
     dependencies = [
         migrations.swappable_dependency(settings.AUTH_USER_MODEL),
-        ('register', '0005_auto_20210215_1913'),
+        ('register', '0004_location_short_code_squashed_0006_merge_20210226_0132'),
     ]
 
     operations = [


### PR DESCRIPTION
Seems that the Django migrations got into a bit of a weird state and it was failing during the deploy of my last PR. I checked the error logs and I believe that this small change might fix it. Let's see...