### PR TITLE
Render custom error templates from register app

### DIFF
--- a/portal/views.py
+++ b/portal/views.py
@@ -8,14 +8,20 @@ from urllib.parse import unquote, urlparse
 
 
 def permission_denied_view(request, exception=None):
+    if settings.APP_SWITCH == "QRCODE":
+        return render(request, "register/403.html", status=403)
     return render(request, "403.html", status=403)
 
 
 def page_not_found(request, exception=None):
+    if settings.APP_SWITCH == "QRCODE":
+        return render(request, "register/404.html", status=404)
     return render(request, "404.html", status=404)
 
 
 def internal_error(request):
+    if settings.APP_SWITCH == "QRCODE":
+        return render(request, "register/500.html", status=500)
     return render(request, "500.html", status=500)
 
 

--- a/register/templates/register/403.html
+++ b/register/templates/register/403.html
@@ -1,0 +1,12 @@
+{% extends 'register/base.html' %}
+{% load i18n settings %}
+
+{% block title %}
+    {% trans "No entry" %}
+{% endblock %}
+
+
+{% block content %}
+    <h1>{% trans "No entry" %}</h1>
+    <p>{% trans "You do not have permission to visit this page." %}</p>
+{% endblock %}

--- a/register/templates/register/404.html
+++ b/register/templates/register/404.html
@@ -1,0 +1,13 @@
+{% extends 'register/base.html' %}
+{% load i18n settings %}
+
+{% block title %}
+    {% trans "Page not found" %}
+{% endblock %}
+
+
+{% block content %}
+    <h1>{% trans "Page not found" %}</h1>
+    <p>{% trans "If you typed the web address, make sure it’s correct." %}</p>
+    <p>{% trans "If you pasted the web address, make sure you copied the entire address." %}</p>
+{% endblock %}

--- a/register/templates/register/500.html
+++ b/register/templates/register/500.html
@@ -1,0 +1,19 @@
+{% extends 'register/base.html' %}
+{% load i18n %}
+
+{% block title %}
+    {% trans "Try again later" %}
+{% endblock %}
+
+
+{% block content %}
+    <h1>{% trans "Try again later" %}</h1>
+    <p>{% trans "Something went wrong with the system. Tell your portal adminstrator as soon as possible." %}</p>
+    <br />
+    <p>{% trans "We need to fix the problem so you can generate keys." %}</p>
+    <p>{% trans "Please contact us with the details of what you were trying to do." %}</p>
+
+    <div class="content-button">
+        <a href="" role='button' draggable='false'>{% trans "Contact us" %}</a>
+    </div>
+{% endblock %}


### PR DESCRIPTION
# Summary | Résumé

In a previous PR the Register site got its own Base template, however the default error pages for the site (500, 403, 404, etc) all extended the Portal base template, which has references to routes that do not exist in the Register app.

This PR introduces error pages specifically for the Register app, and tells the Portal to render the correct error template from the Register app when in Register mode.