### PR TITLE
Stop logging for expired/invalid email confirmation tokens

### DIFF
--- a/register/views.py
+++ b/register/views.py
@@ -84,7 +84,6 @@ def confirm_email(request, pk):
 
         return redirect(reverse_lazy("register:registrant_name"))
     except (EmailConfirmation.DoesNotExist):
-        print("Error: Email verification token does not exist")
         return redirect(reverse_lazy("register:confirm_email_error"))
 
 


### PR DESCRIPTION
# Summary | Résumé

Stop logging these errors as they are triggering an alarm on staging, which is not intentional/necessary.
