### PR TITLE
Merge duplicate Locations

### DIFF
--- a/register/views.py
+++ b/register/views.py
@@ -147,20 +147,22 @@ class LocationWizard(NamedUrlSessionWizardView):
 
     def done(self, form_list, form_dict, **kwargs):
         forms = [form.cleaned_data for form in form_list]
-        location = dict(ChainMap(*forms))
+        data = dict(ChainMap(*forms))
 
-        Location.objects.create(
-            category=location["category"],
-            name=location["name"],
-            address=location["address"],
-            address_2=location["address_2"],
-            city=location["city"],
-            province=location["province"],
-            postal_code=location["postal_code"],
-            contact_name=location["contact_name"],
-            contact_email=location["contact_email"],
-            contact_phone=location["contact_phone"],
+        location, created = Location.objects.get_or_create(
+            name=data["name"],
+            address=data["address"],
+            address_2=data["address_2"],
+            city=data["city"],
+            province=data["province"],
+            postal_code=data["postal_code"],
         )
+
+        location.category = data["category"]
+        location.contact_name = data["contact_name"]
+        location.contact_email = data["contact_email"]
+        location.contact_phone = data["contact_phone"]
+        location.save()
 
         return HttpResponseRedirect(reverse("register:confirmation"))
 


### PR DESCRIPTION
# Summary | Résumé

When creating a new poster, we'll try to merge with an existing Location if there is one, based on the following criteria:
- Location Name (name)
- Address Line 1 (address)
- Address Line 2 (address_2)
- City (city)
- Province (province)
- Postal Code (postal_code)

At the moment, this is a case-sensitive exact-match, so the following Locations would all be considered unique:
- CDS Waffle House, 219 Laurier Avenue West, Ottawa, ON, K1A 1M2
- CDS Waffle House, 219 Laurier Avenue, Ottawa, ON, K1A 1M2
- CDS Waffle House, 219 laurier Avenue, Ottawa, ON, K1A 1M2
- CDS Waffle house, 219 Laurier Avenue, Ottawa, ON, K1A 1M2

TBD if we should introduce any "fuzziness" to this search/match.

If a match is identified, we retrieve that Location and update it with the remaining information:
- Category
- Contact Name
- Contact Email
- Contact Phone

If no match is found, we just create a new Location record.