### PR TITLE
Replaced tables with description lists for accessibility

### DIFF
--- a/outbreaks/templates/confirm.html
+++ b/outbreaks/templates/confirm.html
@@ -12,44 +12,39 @@
 
     <h1>{% trans "Confirm and send" %}</h1>
 
-    <table>
-      <caption class="visually-hidden">{% trans "Notification details" %}</caption>
-      <tbody>
-        <tr>
-            <th scope="row">{% trans "Name" %}</th>
-            <td>{{ location.name }}</td>
-            <td><a href="{% url 'outbreaks:search' %}">{% trans "Change" %}<span class="visually-hidden">{% trans "location" %}</span></a></td>
-        </tr>
-        <tr>
-            <th scope="row">{% trans "Address" %}</th>
-            <td>
-                <address>
-                    <span> {{ location.address }} </span>
-                    <span> {{ location.city }}, {{ location.province }} </span>
-                    <span> {{ location.postal_code }} </span>
-                </address>
-            </td>
-            <td>
+    <dl class="summary-list">
+        <div class="summary-list__row">
+            <dt class="summary-list__key">{% trans "Name" %}</dt>
+            <dd class="summary-list__value">{{ location.name }}</dd>
+            <dd class="summary-list__actions"><a href="{% url 'outbreaks:search' %}">{% trans "Change" %}<span class="visually-hidden">{% trans "location" %}</span></a></dd>
+        </div>
+        <div class="summary-list__row">
+            <dt class="summary-list__key">{% trans "Address" %}</dt>
+            <dd class="summary-list__value">
+                {{ location.address }}<br>
+                {{ location.city }}, {{ location.province }}<br>
+                {{ location.postal_code }}<br>
+            </dd>
+            <dd class="summary-list__actions">
                 <a href="{{ map_link }}" target="_blank">{% trans "Show on map" %}</a>
-            </td>
-        </tr>
-        <tr>
-            <th scope="row">{% trans "Type" %}</th>
-            <td>{{ location.category }}</td>
-            <td><a href="{% url 'outbreaks:search' %}">{% trans "Change" %}<span class="visually-hidden">{% trans "location" %}</span></a></td>
-        </tr>
-        <tr>
-            <th scope="row">{% trans "Date(s)" %}</th>
-            <td>{{ dates|join:", " }}</td>
-            <td><a href="{% url 'outbreaks:datetime' %}">{% trans "Change" %}<span class="visually-hidden">{% trans "dates" %}</span></a></td>
-        </tr>
-        <tr>
-            <th scope="row">{% trans "Severity" %}</th>
-            <td>{{ alert_level }}</td>
-            <td><a href="{% url 'outbreaks:severity' %}">{% trans "Change" %}<span class="visually-hidden">{% trans "severity" %}</span></a></td>
-        </tr>
-      </tbody>
-    </table>
+            </dd>
+        </div>
+        <div class="summary-list__row">
+            <dt class="summary-list__key">{% trans "Type" %}</dt>
+            <dd class="summary-list__value">{{ location.category }}</dd>
+            <dd class="summary-list__actions"><a href="{% url 'outbreaks:search' %}">{% trans "Change" %}<span class="visually-hidden">{% trans "location" %}</span></a></dd>
+        </div>
+        <div class="summary-list__row">
+            <dt class="summary-list__key">{% trans "Date(s)" %}</dt>
+            <dd class="summary-list__value">{{ dates|join:", " }}</dd>
+            <dd class="summary-list__actions"><a href="{% url 'outbreaks:datetime' %}">{% trans "Change" %}<span class="visually-hidden">{% trans "dates" %}</span></a></dd>
+        </div>
+        <div class="summary-list__row">
+            <dt class="summary-list__key">{% trans "Severity" %}</dt>
+            <dd class="summary-list__value">{{ alert_level }}</dd>
+            <dd class="summary-list__actions"><a href="{% url 'outbreaks:severity' %}">{% trans "Change" %}<span class="visually-hidden">{% trans "severity" %}</span></a></dd>
+        </div>
+    </dl>
 
     <p>{% trans "By selecting “Notify people who were there”,  you confirm you believe this information is correct and complete." %}</p>
 

--- a/outbreaks/templates/profile.html
+++ b/outbreaks/templates/profile.html
@@ -13,46 +13,41 @@
   {% if location %}
     <h1>{% trans "Place profile" %}</h1>
 
-    <table>
-      <caption class="visually-hidden">{% trans "Location profile" %}</caption>
-      <tbody>
-        <tr>
-            <th scope="row">{% trans "Name" %}</th>
-            <td>{{ location.name }}</td>
-            <td></td>
-        </tr>
-        <tr>
-            <th scope="row">{% trans "Address" %}</th>
-            <td>
-                <address>
-                    <span> {{ location.address }} </span>
-                    <span> {{ location.city }}, {{ location.province }} </span>
-                    <span> {{ location.postal_code }} </span>
-                </address>
-            </td>
-            <td>
+    <dl class="summary-list">
+        <div class="summary-list__row">
+            <dt class="summary-list__key">{% trans "Name" %}</dt>
+            <dd class="summary-list__value">{{ location.name }}</dd>
+            <dd class="summary-list__actions"></dd>
+        </div>
+        <div class="summary-list__row">
+            <dt class="summary-list__key">{% trans "Address" %}</dt>
+            <dd class="summary-list__value">
+                {{ location.address }}<br>
+                {{ location.city }}, {{ location.province }}<br>
+                {{ location.postal_code }}
+            </dd>
+            <dd class="summary-list__actions">
                 <a href="{{ map_link }}" target="_blank">
-                        {% trans "Show on map" %}
+                    {% trans "Show on map" %}
                 </a>
-            </td>
-        </tr>
-        <tr>
-            <th scope="row">{% trans "Contact email" %}</th>
-            <td>{{ location.contact_email }}</td>
-            <td></td>
-        </tr>
-        <tr>
-            <th scope="row">{% trans "Contact phone" %}</th>
-            <td>{{ location.contact_phone }}</td>
-            <td></td>
-        </tr>
-        <tr>
-            <th scope="row">{% trans "Number of prior notifications" %}</th>
-            <td>{{ num_notifications }}</td>
-            <td></td>
-        </tr>
-      </tbody>
-    </table>
+            </dd>
+        </div>
+        <div class="summary-list__row">
+            <dt class="summary-list__key">{% trans "Contact email" %}</dt>
+            <dd class="summary-list__value">{{ location.contact_email }}</dd>
+            <dd class="summary-list__actions"></dd>
+        </div>
+        <div class="summary-list__row">
+            <dt class="summary-list__key">{% trans "Contact phone" %}</dt>
+            <dd class="summary-list__value">{{ location.contact_phone }}</dd>
+            <dd class="summary-list__actions"></dd>
+        </div>
+        <div class="summary-list__row">
+            <dt class="summary-list__key">{% trans "Number of prior notifications" %}</dt>
+            <dd class="summary-list__value">{{ num_notifications }}</dd>
+            <dd class="summary-list__actions"></dd>
+        </div>
+    </dl>
 
   {% else %}
     <p>{% trans "Place not found." %}</p>

--- a/outbreaks/templates/search.html
+++ b/outbreaks/templates/search.html
@@ -17,7 +17,7 @@
 
     <div class="fieldWrapper--container{% if form.non_field_errors %} fieldWrapper--container--has-error{% endif %} search_bar">
       <div class="fieldWrapper{% if field.errors %} fieldWrapper--has-error{% endif %}">
-        <label for="id_search_text" class="visually-hidden">Search: </label>
+        <label for="id_search_text" class="visually-hidden">{{ _("Search") }}</label>
         <input type="text" name="search_text" size="30" autocomplete="on" id="id_search_text">
         <button type="submit">
           {{ _("Search") }}


### PR DESCRIPTION
# Summary | Résumé

Closes #414. When tables don't have column headings, voiceover gets confused and reads the row headings as if they were column headings. Gov.uk uses the descriptive list element in this case - `<dl>`, and that is consistent with other parts of the app such as `register/templates/register/summary.html`.

I also added a translation I missed for the "Search" label.

Minor formatting change due to swapping out the `<table>` - I think the row height is a bit smaller than before: 
<img width="860" alt="Screen Shot 2021-03-09 at 2 03 33 PM" src="https://user-images.githubusercontent.com/5498428/110537691-3ed35900-80e0-11eb-84cf-a46a3ac44349.png">
