### PR TITLE
Increased the back anchor padding-left to make room for the chevron

### DIFF
--- a/profiles/static/scss/components/_links.scss
+++ b/profiles/static/scss/components/_links.scss
@@ -12,7 +12,7 @@
   margin-bottom: $space-xl;
 
   a {
-    padding-left: 0.3em;
+    padding-left: 0.45em;
 
     &::before {
       @include chevron("left");


### PR DESCRIPTION
# Summary | Résumé

Closes #423. I got the width of the chevron from here: https://github.com/cds-snc/covid-alert-portal/blob/main/profiles/static/scss/_mixins.scss#L24

Here is what it looks like now:
<img width="454" alt="Screen Shot 2021-03-09 at 3 11 36 PM" src="https://user-images.githubusercontent.com/5498428/110545441-54e61700-80ea-11eb-8ac1-1fb92d6ddc26.png">
