### PR TITLE
Address line 2 now only appears if it exists on QR location summary page

### DIFF
--- a/register/templates/register/summary.html
+++ b/register/templates/register/summary.html
@@ -55,7 +55,9 @@
                 </dt>
                 <dd class="summary-list__value">
                     {{ form_data.address }}<br>
-                    {{ form_data.address_2 }}<br>
+                    {% if form_data.address_2 %}
+                        {{ form_data.address_2 }}<br>
+                    {% endif %}
                     {{ form_data.city }}<br>
                     {{ form_data.province }}<br>
                     {{ form_data.postal_code }}


### PR DESCRIPTION
# Summary | Résumé

Closes #422. 

Line 2 not filled out:
<img width="867" alt="Screen Shot 2021-03-09 at 3 29 17 PM" src="https://user-images.githubusercontent.com/5498428/110547053-a099c000-80ec-11eb-88e0-076008d05f8c.png">

Line 2 filled out:
<img width="840" alt="Screen Shot 2021-03-09 at 3 29 51 PM" src="https://user-images.githubusercontent.com/5498428/110547086-af807280-80ec-11eb-8023-5c553ea9c1eb.png">
