### PR TITLE
DON'T MERGE - Little hack to track session timeouts

### DIFF
--- a/portal/templates/includes/flash_messages.html
+++ b/portal/templates/includes/flash_messages.html
@@ -4,7 +4,11 @@
     <div class="messages--container" role="alert">
         <ul class="messages">
         {% for message in messages %}
-            <li{% if message.tags %} class="{{ message.tags }}"{% endif %}>{{ message }}</li>
+            <li
+            {% if message.tags %} class="{{ message.tags }}"{% endif %}
+            {% if message.tags == "logout info" %} onload="gtag('event', 'event_name', {'value': 'timeout'});" {% endif %}>
+                {{ message }}
+            </li>
         {% endfor %}
         </ul>
     </div>


### PR DESCRIPTION
Currently when a session timesout the user is redirected back to the login page, but with a message window at the top of the screen. If we modify the html template for this message window we can catch this event and trigger a javascript call for a Google analytics custom event. The custom event would then have to be configured in the GA admin dashboard to receive and track these events. To me it seems like it should work, but we won't know until it gets tested in production.