### PR TITLE
Use the user's local timezone in alerting flow

### DIFF
--- a/outbreaks/forms.py
+++ b/outbreaks/forms.py
@@ -67,6 +67,8 @@ class DateForm(HealthcareBaseForm):
 
     def get_valid_date(self, data, i):
         tz = pytz.timezone(settings.TIME_ZONE or "UTC")
+        print("settings.TIME_ZONE", settings.TIME_ZONE)
+        print("tz", tz)
         return datetime(
             year=int(data.get(f"year_{i}", -1)),
             month=int(data.get(f"month_{i}", -1)),

--- a/outbreaks/forms.py
+++ b/outbreaks/forms.py
@@ -1,11 +1,9 @@
 from django import forms
 from django.utils.translation import gettext_lazy as _
 from django.core.exceptions import ValidationError
-from django.conf import settings
 from portal.widgets import CDSRadioWidget
 from portal.forms import HealthcareBaseForm
 from datetime import datetime
-import pytz
 from dateutil import tz
 
 severity_choices = [

--- a/outbreaks/forms.py
+++ b/outbreaks/forms.py
@@ -6,6 +6,7 @@ from portal.widgets import CDSRadioWidget
 from portal.forms import HealthcareBaseForm
 from datetime import datetime
 import pytz
+from dateutil import tz
 
 severity_choices = [
     ("1", _("Self-monitor")),
@@ -65,15 +66,13 @@ class DateForm(HealthcareBaseForm):
         if not is_valid:
             raise ValidationError(error_msg)
 
-    def get_valid_date(self, data, i):
-        tz = pytz.timezone(settings.TIME_ZONE or "UTC")
-        print("settings.TIME_ZONE", settings.TIME_ZONE)
-        print("tz", tz)
+    def get_valid_date(self, data, i, tz_offset_s=0):
+        tz_local = tz.tzoffset("NA", tz_offset_s)
         return datetime(
             year=int(data.get(f"year_{i}", -1)),
             month=int(data.get(f"month_{i}", -1)),
             day=int(data.get(f"day_{i}", -1)),
-        ).replace(tzinfo=tz)
+        ).replace(tzinfo=tz_local)
 
     def add_duplicate_error(self, index):
         error_msg = _(

--- a/outbreaks/templates/datetime.html
+++ b/outbreaks/templates/datetime.html
@@ -66,6 +66,8 @@
       </button>
     </div>
 
+    <div id="timezone-offset">abc</div>
+
     <div class="content-button">
       <button type="submit">
         {{ _("Next") }}

--- a/outbreaks/templates/datetime.html
+++ b/outbreaks/templates/datetime.html
@@ -28,6 +28,8 @@
   <form method="post" id="form--{{ request.resolver_match.url_name }}">
     {% csrf_token %}
 
+    <input type="hidden" id="tz-offset" name="tz-offset" value="" />
+
     {% for fieldset in form.fieldsets %}
       <div class="fieldWrapper--container{% if fieldset.error %} fieldWrapper--container--has-error{% endif %}">
         <div class="fieldWrapper{% if fieldset.error %} fieldWrapper--has-error{% endif %}">
@@ -65,8 +67,6 @@
         {{ _("Remove a date") }}
       </button>
     </div>
-
-    <div id="timezone-offset">abc</div>
 
     <div class="content-button">
       <button type="submit">

--- a/profiles/static/js/script.js
+++ b/profiles/static/js/script.js
@@ -20,6 +20,9 @@ if (form) {
 }
 
 // get user's timezone
-var now = new Date();
-var timezoneOffset = now.getTimezoneOffset();
-document.querySelector("#tz-offset").setAttribute("value", timezoneOffset);
+var tzInput = document.querySelector("#tz-offset");
+if (tzInput) {
+  var now = new Date();
+  var timezoneOffset = now.getTimezoneOffset();
+  tzInput.setAttribute("value", timezoneOffset);
+}

--- a/profiles/static/js/script.js
+++ b/profiles/static/js/script.js
@@ -22,4 +22,4 @@ if (form) {
 // get user's timezone
 var now = new Date();
 var timezoneOffset = now.getTimezoneOffset();
-document.querySelector("#timezone-offset").innerHTML = timezoneOffset;
+document.querySelector("#tz-offset").setAttribute("value", timezoneOffset);

--- a/profiles/static/js/script.js
+++ b/profiles/static/js/script.js
@@ -18,3 +18,8 @@ if (form) {
     form.querySelector("button").disabled = true;
   });
 }
+
+// get user's timezone
+var now = new Date();
+var timezoneOffset = now.getTimezoneOffset();
+document.querySelector("#timezone-offset").innerHTML = timezoneOffset;


### PR DESCRIPTION
# Summary | Résumé

Closes #438. What I did:
- added some js to populate a hidden `<input>` with the user's browser's timezone offset
- added the hidden `<input>` to the datetime.html template
- verified that this input element is not visible to screenreaders (works the same way as the csrf input)
- sending this tz offset to the server so the correct utc timestamp is generated
- added this offset to the user's session so it can be used to display the saved utc time as a local time on the "confirm" and "confirmed" pages
