### PR TITLE
Remove check flag on migrations to run migrations

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 sleep 5
 # Apply database migrations
 echo "Apply database migrations"
-python manage.py migrate --noinput --check
+python manage.py migrate --noinput
 
 # Create default superuser if variables are set
 echo "Check if creating default super user"


### PR DESCRIPTION
# Summary | Résumé

A previous PR added this `--check` flag to the migrate command. This did not have the intended effect, instead it just stopped running migrations.