### PR TITLE
Update Canada Post Address Complete API key

### DIFF
--- a/register/static/register/js/address-autocomplete.js
+++ b/register/static/register/js/address-autocomplete.js
@@ -3,7 +3,7 @@
  * but it'll be locked to our domain and is not sensitive
  * https://www.canadapost.ca/pca/support/kb/address-complete-basics/#safe
  */
-const key = 'KN31-NC34-UE92-KU11'
+const key = 'XF51-CY97-JE96-HK81'
 
 /**
  * Just a wrapper around xhr for convenience.


### PR DESCRIPTION
# Summary | Résumé

We are currently using a Trial account of the Canada Post API. The Trial account is only good for 14 days. So every 14 days, we need to create a new Trial account and create a new API key. Whenever procurement gets sorted out, this problem will go away.
