### PR TITLE
Fix image alignment issue on confirmation

### DIFF
--- a/register/static/register/scss/_custom.scss
+++ b/register/static/register/scss/_custom.scss
@@ -64,12 +64,11 @@ body.qrcode {
         width: 100%;
         a {
             display: inline;
+            img {
+                margin-left: $space-sm;
+                vertical-align: middle;
+            }
         }
-        img {
-            margin-left: $space-sm;
-            vertical-align: middle;
-        }
-
     }
 
     .reminder {


### PR DESCRIPTION
# Summary | Résumé

Fixes an image alignment issue on the Confirmation screen:

Before | After
------------ | -------------
![image](https://user-images.githubusercontent.com/1187115/114444391-d1ae5a00-9b9c-11eb-9708-1a9e29ceece5.png) | ![image](https://user-images.githubusercontent.com/1187115/114444427-e2f76680-9b9c-11eb-8708-576ac2bbc9a6.png)
