### PR TITLE
Add step to verify sass files can compile

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,3 +41,8 @@ jobs:
         uses: VaultVulp/action-pipenv@v2.0.1
         with:
           command: run test # Run custom `test` command defined in the `[scripts]` block of Pipfile
+
+      - name: Check SASS
+        uses: VaultVulp/action-pipenv@v2.0.1
+        with:
+          command: run css

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,6 +11,7 @@ jobs:
         uses: actions/setup-python@v1
         with:
           python-version: ${{ matrix.python-version }}
+
       - uses: dschep/install-pipenv-action@v1
       - name: Install dependecies
         uses: VaultVulp/action-pipenv@v2.0.1
@@ -31,6 +32,13 @@ jobs:
         uses: VaultVulp/action-pipenv@v2.0.1
         with:
           command: run css
+
+      - uses: vishnudxb/cancel-workflow@v1.2
+        if: failure()
+        with:
+          repo: octocat/hello-world
+          workflow_id: ${{ github.run_id }}
+          access_token: ${{ github.token }}
       
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,35 @@ name: Django CI
 on: push
 
 jobs:
+  code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v1
+        with:
+          python-version: ${{ matrix.python-version }}
+      - uses: dschep/install-pipenv-action@v1
+      - name: Install dependecies
+        uses: VaultVulp/action-pipenv@v2.0.1
+        with:
+          command: install -d # Install all dependencies, including development ones
+      
+      - name: Check format with black
+        uses: VaultVulp/action-pipenv@v2.0.1
+        with:
+          command: run format --check
+
+      - name: Lint for style with flake8
+        uses: VaultVulp/action-pipenv@v2.0.1
+        with:
+          command: run lint
+
+      - name: Check SASS
+        uses: VaultVulp/action-pipenv@v2.0.1
+        with:
+          command: run css
+      
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -27,22 +56,7 @@ jobs:
         with:
           command: check
 
-      - name: Check format with black
-        uses: VaultVulp/action-pipenv@v2.0.1
-        with:
-          command: run format --check
-
-      - name: Lint for style with flake8
-        uses: VaultVulp/action-pipenv@v2.0.1
-        with:
-          command: run lint
-
       - name: Test
         uses: VaultVulp/action-pipenv@v2.0.1
         with:
           command: run test # Run custom `test` command defined in the `[scripts]` block of Pipfile
-
-      - name: Check SASS
-        uses: VaultVulp/action-pipenv@v2.0.1
-        with:
-          command: run css

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,13 +32,6 @@ jobs:
         uses: VaultVulp/action-pipenv@v2.0.1
         with:
           command: run css
-
-      - uses: vishnudxb/cancel-workflow@v1.2
-        if: failure()
-        with:
-          repo: octocat/hello-world
-          workflow_id: ${{ github.run_id }}
-          access_token: ${{ github.token }}
       
   test:
     runs-on: ubuntu-latest

--- a/register/static/register/scss/_custom.scss
+++ b/register/static/register/scss/_custom.scss
@@ -145,3 +145,4 @@ body.qrcode {
     .step-one-info {
         margin-bottom: $space-lg;
     }
+}

--- a/register/static/register/scss/_custom.scss
+++ b/register/static/register/scss/_custom.scss
@@ -145,4 +145,3 @@ body.qrcode {
     .step-one-info {
         margin-bottom: $space-lg;
     }
-}


### PR DESCRIPTION
# Summary | Résumé

Adds a GithubActions check to make sure SASS files can be compiled. Also reorganized the tests a bit, separating code/syntax checks into their own job.

## To test
You can see in the commit history of this PR a [purposely broken commit with SASS syntax error](https://github.com/cds-snc/covid-alert-portal/pull/480/commits/1873ba661ed5a1a056f70e38702a70ba5dd6cad5) that caused tests to fail, then later they passed when the [syntax error was fixed](https://github.com/cds-snc/covid-alert-portal/pull/480/commits/3707c8128d17dc3f097e5917bcc2fe27fd218dc3).