### PR TITLE
Add location address to poster email subject

### DIFF
--- a/register/views.py
+++ b/register/views.py
@@ -208,6 +208,7 @@ class LocationWizard(NamedUrlSessionWizardView):
             to_email,
             {
                 "location_name": location.name,
+                "location_address": location.address,
                 "english_poster": {
                     "file": en_poster,
                     "filename": "poster-en.pdf",


### PR DESCRIPTION
# Summary | Résumé

Adds location_address to the notify payload for the poster email. Notify template already updated.