### PR TITLE
Fix localization on profile page plus add browser tz support to request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - QR Code Registration form with Email verification
 - Location search with Canada Post Address Complete API
 
+## [1.19.4] - 2021-04-28
+
+### Updated
+
+- Fix for manage profiles page when showing last password change timestamp
+
 ## [1.19.3] - 2021-04-08
 
 ### Updated

--- a/portal/middleware.py
+++ b/portal/middleware.py
@@ -8,7 +8,7 @@ class TZMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
-        browser_tz = request.COOKIES.get('browserTimezone')
+        browser_tz = request.COOKIES.get("browserTimezone")
         tz = None
         if browser_tz:
             try:
@@ -20,8 +20,10 @@ class TZMiddleware:
 
         def replace_to_local_tz(dttm):
             return dttm.replace(tzinfo=tz)
+
         def localize_dttm(dttm):
             return tz.localize(dttm)
+
         def convert_to_local_tz_from_utc(utc_dttm):
             return utc_dttm.astimezone(tz=tz)
 

--- a/portal/middleware.py
+++ b/portal/middleware.py
@@ -1,0 +1,33 @@
+import pytz
+from pytz import UnknownTimeZoneError
+from django.conf import settings
+
+
+class TZMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        browser_tz = request.COOKIES.get('browserTimezone')
+        tz = None
+        if browser_tz:
+            try:
+                tz = pytz.timezone(browser_tz)
+            except UnknownTimeZoneError:
+                pass
+        if not tz:
+            tz = pytz.timezone(settings.PORTAL_LOCAL_TZ)
+
+        def replace_to_local_tz(dttm):
+            return dttm.replace(tzinfo=tz)
+        def localize_dttm(dttm):
+            return tz.localize(dttm)
+        def convert_to_local_tz_from_utc(utc_dttm):
+            return utc_dttm.astimezone(tz=tz)
+
+        request.replace_to_local_tz = replace_to_local_tz
+        request.localize_dttm = localize_dttm
+        request.convert_to_local_tz_from_utc = convert_to_local_tz_from_utc
+
+        response = self.get_response(request)
+        return response

--- a/portal/middleware.py
+++ b/portal/middleware.py
@@ -1,5 +1,4 @@
 import pytz
-from pytz import UnknownTimeZoneError
 from django.conf import settings
 
 
@@ -13,22 +12,14 @@ class TZMiddleware:
         if browser_tz:
             try:
                 tz = pytz.timezone(browser_tz)
-            except UnknownTimeZoneError:
+            except pytz.UnknownTimeZoneError:
                 pass
         if not tz:
             tz = pytz.timezone(settings.PORTAL_LOCAL_TZ)
 
-        def replace_to_local_tz(dttm):
-            return dttm.replace(tzinfo=tz)
-
-        def localize_dttm(dttm):
-            return tz.localize(dttm)
-
         def convert_to_local_tz_from_utc(utc_dttm):
             return utc_dttm.astimezone(tz=tz)
 
-        request.replace_to_local_tz = replace_to_local_tz
-        request.localize_dttm = localize_dttm
         request.convert_to_local_tz_from_utc = convert_to_local_tz_from_utc
 
         response = self.get_response(request)

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -117,6 +117,7 @@ MIDDLEWARE = [
     "csp.middleware.CSPMiddleware",
     "easyaudit.middleware.easyaudit.EasyAuditMiddleware",
     "waffle.middleware.WaffleMiddleware",
+    "portal.middleware.TZMiddleware"
 ]
 
 ROOT_URLCONF = "portal.urls"

--- a/portal/settings.py
+++ b/portal/settings.py
@@ -117,7 +117,7 @@ MIDDLEWARE = [
     "csp.middleware.CSPMiddleware",
     "easyaudit.middleware.easyaudit.EasyAuditMiddleware",
     "waffle.middleware.WaffleMiddleware",
-    "portal.middleware.TZMiddleware"
+    "portal.middleware.TZMiddleware",
 ]
 
 ROOT_URLCONF = "portal.urls"

--- a/profiles/static/js/script.js
+++ b/profiles/static/js/script.js
@@ -30,3 +30,5 @@ document.addEventListener('keypress', function (e) {
       }
     }
 });
+
+document.cookie = 'browserTimezone=' + Intl.DateTimeFormat().resolvedOptions().timeZone + '; path=/';

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -401,7 +401,9 @@ class UserProfileView(Is2FAMixin, ProvinceAdminMixin, DetailView):
                 .datetime
             )
             recent_date = self.request.convert_to_local_tz_from_utc(recent_date)
-            context["last_updated_datetime"] = recent_date.strftime(get_time_format(cur_lang))
+            context["last_updated_datetime"] = recent_date.strftime(
+                get_time_format(cur_lang)
+            )
 
         except AttributeError:
             context["last_updated_datetime"] = ""

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -55,7 +55,6 @@ from .forms import (
 )
 
 from django.utils import translation
-import locale
 
 
 class YubikeyVerifyView(FormView):
@@ -391,9 +390,6 @@ class UserProfileView(Is2FAMixin, ProvinceAdminMixin, DetailView):
         )
 
         try:
-
-            cur_lang = translation.get_language()
-
             recent_date = (
                 CRUDEvent.objects.filter(user_id=self.request.user.id)
                 .filter(changed_fields__icontains="password")
@@ -402,9 +398,8 @@ class UserProfileView(Is2FAMixin, ProvinceAdminMixin, DetailView):
             )
             recent_date = self.request.convert_to_local_tz_from_utc(recent_date)
             context["last_updated_datetime"] = recent_date.strftime(
-                get_time_format(cur_lang)
+                get_time_format(translation.get_language())
             )
-
         except AttributeError:
             context["last_updated_datetime"] = ""
 

--- a/profiles/views.py
+++ b/profiles/views.py
@@ -23,6 +23,7 @@ from django.db.models.expressions import RawSQL
 
 from otp_yubikey.models import RemoteYubikeyDevice
 
+from outbreaks.views import get_time_format
 from portal.mixins import (
     ThrottledMixin,
     Is2FAMixin,
@@ -399,13 +400,8 @@ class UserProfileView(Is2FAMixin, ProvinceAdminMixin, DetailView):
                 .first()
                 .datetime
             )
-
-            if cur_lang == "en":
-                locale.setlocale(locale.LC_ALL, "en_ca")
-                context["last_updated_datetime"] = recent_date.strftime("%B %d, %Y")
-            if cur_lang == "fr":
-                locale.setlocale(locale.LC_ALL, "fr_ca")
-                context["last_updated_datetime"] = recent_date.strftime("%d %B %Y")
+            recent_date = self.request.convert_to_local_tz_from_utc(recent_date)
+            context["last_updated_datetime"] = recent_date.strftime(get_time_format(cur_lang))
 
         except AttributeError:
             context["last_updated_datetime"] = ""


### PR DESCRIPTION
Trello:
https://trello.com/c/gG8YZyrV/768-bugfix-date-localization-for-password-last-updated-on-profile-view-does-not-work-on-the-production-server

Steps to reproduce error:
* Login to portal
* Click manage account
* Error should be evident if password has been changed > 0 times

Fix:
* Refactor to more appropriate tz localization
* Add support for local browser tz as a cookie
* Maintain ability to get local time in middleware