### PR TITLE
Use list_display and model properties for csv output

### DIFF
--- a/outbreaks/admin.py
+++ b/outbreaks/admin.py
@@ -14,14 +14,11 @@ class NotificationAdmin(admin.ModelAdmin, ExportCsvMixin):
         "created_by",
         "severity",
         "location",
-        "short_code",
+        "location_shortcode",
     ]
     actions = ["export_as_csv"]
 
     list_display_links = None
-
-    def short_code(self, obj):
-        return obj.location.short_code
 
     def has_add_permission(self, request, obj=None):
         return False

--- a/outbreaks/models.py
+++ b/outbreaks/models.py
@@ -18,6 +18,10 @@ class Notification(models.Model):
     )
     location = models.ForeignKey(Location, on_delete=models.PROTECT, editable=False)
 
+    @property
+    def location_shortcode(self):
+        return self.location.short_code
+
     class Meta:
         indexes = [
             models.Index(fields=["start_date"]),

--- a/portal/mixins.py
+++ b/portal/mixins.py
@@ -138,9 +138,10 @@ class ProvinceAdminMixin(UserPassesTestMixin):
 
 class ExportCsvMixin:
     def export_as_csv(self, request, queryset):
-
         meta = self.model._meta
-        field_names = [field.name for field in meta.fields]
+
+        # Will only work if list_display is made up of only model properties
+        field_names = self.list_display
 
         response = HttpResponse(content_type="text/csv")
         response["Content-Disposition"] = "attachment; filename={}.csv".format(meta)

--- a/register/admin.py
+++ b/register/admin.py
@@ -50,7 +50,7 @@ class RegistrantAdmin(admin.ModelAdmin, ExportCsvMixin):
 @admin.register(Location)
 class LocationAdmin(admin.ModelAdmin, ExportCsvMixin):
     date_hierarchy = "created"
-    list_display = ["name", "city", "province", "short_code", "registrant"]
+    list_display = ["name", "city", "province", "short_code", "registrant_id", "registrant_email"]
     list_filter = (
         "province",
         "city",

--- a/register/admin.py
+++ b/register/admin.py
@@ -50,7 +50,14 @@ class RegistrantAdmin(admin.ModelAdmin, ExportCsvMixin):
 @admin.register(Location)
 class LocationAdmin(admin.ModelAdmin, ExportCsvMixin):
     date_hierarchy = "created"
-    list_display = ["name", "city", "province", "short_code", "registrant_id", "registrant_email"]
+    list_display = [
+        "name",
+        "city",
+        "province",
+        "short_code",
+        "registrant_id",
+        "registrant_email",
+    ]
     list_filter = (
         "province",
         "city",

--- a/register/models.py
+++ b/register/models.py
@@ -49,6 +49,10 @@ class Location(models.Model):
     created = models.DateTimeField(default=timezone.now)
     registrant = models.ForeignKey(Registrant, on_delete=models.SET_NULL, null=True)
 
+    @property
+    def registrant_email(self):
+        return self.registrant.email
+
     # Override save method to generate a unique short code for poster
     def save(self, *args, **kwargs):
         if not self.short_code:


### PR DESCRIPTION
# Summary | Résumé

The previous version of CSV output would only render fields listed in the originating model Meta, and so wouldn't include any related properties that were added into the Admin list view.

This changes the mixin to use the list of properties from the Admin view `self.list_display` so that we are dumping out what the user sees onscreen.

This requires that everything in the list_display is a Model property, so had to convert one admin view property to model propoerty.

## To test
Visit the Admin section Locations, Registrants, or Notifications, and try exporting data. The CSV will include the same data you see on screen, including model properties (note specifically Locations->registrant_email and registrant_id)