### PR TITLE
Share the language selection cookie en/fr URLs

### DIFF
--- a/portal/settings.py
+++ b/portal/settings.py
@@ -53,6 +53,9 @@ ALLOWED_HOSTS = [
     gethostname(),
 ]
 
+if is_prod:
+    LANGUAGE_COOKIE_DOMAIN = "alpha.canada.ca"
+
 if not DEBUG and not TESTING:
     try:
         # this will fail locally because the macbook name can't be resolved to an IP


### PR DESCRIPTION
# Summary | Résumé

Sets the Language Selection cookie at the *.alpha.canada.ca level so that it can be shared across the language-specific urls.

Previously there was a bug when switching languages- because the language selection cookie was only set on the currently selected url, it caused a weird situation where the cookie would be out of sync with the current language and you would need to click the language switch twice to actually switch languages. 

This only happens in environments with language-specific URLs. You can see it on Production right now for either the Registration site or Portal.

## To test
Testing this is tricky because you need to setup language-specific URLs for your local environment. Here's what I did:
- Add two `/etc/hosts` entries pointing to localhost
  ![image](https://user-images.githubusercontent.com/1187115/118159321-df990a00-b3ea-11eb-9e4e-a851873646b4.png)
- Add those urls to ALLOWED_HOSTS and create the following environment variables in .env:
  ![image](https://user-images.githubusercontent.com/1187115/118159443-048d7d00-b3eb-11eb-8bf4-ac38f46aaf7a.png)

Now you have a multilingual-url scheme. If you're following my example, note that I used `.cc` instead of `.ca` for testing purposes - if you do the same, you'll have to modify the `LANGUAGE_COOKIE_DOMAIN` to whatever your parent tld is.

Now you should be able to switch languages and have the domains switch out properly. You can inspect the cookie that is being set at the .alpha.canada.cc domain and is shared across the two urls.