### PR TITLE
Only set the cookie domain on production

### DIFF
--- a/portal/settings.py
+++ b/portal/settings.py
@@ -53,7 +53,7 @@ ALLOWED_HOSTS = [
     gethostname(),
 ]
 
-if is_prod:
+if is_prod and "alpha.canada.ca" in gethostname():
     LANGUAGE_COOKIE_DOMAIN = "alpha.canada.ca"
 
 if not DEBUG and not TESTING:


### PR DESCRIPTION
# Summary | Résumé

Bugfix to previous PR #525 - the is_prod test resolves true on Staging as well. Added a check for the domain so this only happens on Production.