### PR TITLE
Make registrants editable

### DIFF
--- a/register/admin.py
+++ b/register/admin.py
@@ -43,9 +43,6 @@ class RegistrantAdmin(admin.ModelAdmin, ExportCsvMixin):
     search_fields = ["id", "email"]
     actions = ["export_as_csv"]
 
-    def has_change_permission(self, request, obj=None):
-        return False
-
 
 @admin.register(Location)
 class LocationAdmin(admin.ModelAdmin, ExportCsvMixin):

--- a/register/views.py
+++ b/register/views.py
@@ -201,10 +201,8 @@ class LocationWizard(NamedUrlSessionWizardView):
         en_poster = get_encoded_poster(location, "en")
         fr_poster = get_encoded_poster(location, "fr")
 
-        to_email = self.request.session["registrant_email"]
-
         send_email(
-            to_email,
+            registrant.email,
             {
                 "location_name": location.name,
                 "location_address": location.address,


### PR DESCRIPTION
# Summary | Résumé

In order to conduct load testing without sending a bunch of emails, make the Registrant table editable in the Admin panel so that we can change the registrant email to a test email from amazon that will return a success response without actually sending anything.
