### PR TITLE
feat: pin local Terraform version with asdf

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,7 @@ db.sqlite3
 !/staticfiles/.gitkeep
 __pycache__
 *.tfstate*
-secrets.tfvars
+secrets*.tfvars
 .terraform/
 *.tfplan
 .coverage

--- a/config/terraform/aws/.tool-versions
+++ b/config/terraform/aws/.tool-versions
@@ -1,0 +1,1 @@
+terraform 0.13.1


### PR DESCRIPTION
# Summary
* Pin local Terraform version with [asdf](https://asdf-vm.com/#/core-manage-asdf) to ensure it matches the CI Terraform version.
* Git ignore `secrets.auto.tfvars` so the variable values are automatically picked up by Terraform commands.

# Expected infra changes
* None

# Notes
To use asdf:
1. Setup [asdf](https://asdf-vm.com/#/core-manage-asdf).
2. Add asdf Terraform plugin:
```sh
asdf plugin-add terraform https://github.com/asdf-community/asdf-hashicorp.git
```
3. Change directories to `config/infrastructure/aws` and run `asdf install`.