### PR TITLE
enable autoscaling on staging for load testing

### DIFF
--- a/config/terraform/aws/variables.auto.tfvars
+++ b/config/terraform/aws/variables.auto.tfvars
@@ -31,7 +31,7 @@ dual_urls             = "False"
 
 #Autoscaling ECS
 
-portal_autoscale_enabled = false
+portal_autoscale_enabled = true
 
 ###
 # AWS VPC - networking.tf


### PR DESCRIPTION
# Summary | Résumé

This will enable autoscaling on Staging so that we can run our Load tests against it and hopefully see the infrastructure scale up.