### PR TITLE
fix: ECS service autoscaling targets and policies

### DIFF
--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -223,7 +223,7 @@ resource "aws_ecs_service" "qrcode" {
 resource "aws_appautoscaling_target" "portal" {
   count              = var.portal_autoscale_enabled ? 1 : 0
   service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.covidportal.cluster}/${aws_ecs_service.covidportal.name}"
+  resource_id        = "service/${aws_ecs_cluster.covidportal.name}/${aws_ecs_service.covidportal.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   min_capacity       = var.min_capacity
   max_capacity       = var.max_capacity
@@ -232,9 +232,9 @@ resource "aws_appautoscaling_policy" "portal_cpu" {
   count              = var.portal_autoscale_enabled ? 1 : 0
   name               = "portal_cpu"
   policy_type        = "TargetTrackingScaling"
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.covidportal.cluster}/${aws_ecs_service.covidportal.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = aws_appautoscaling_target.portal[count.index].service_namespace
+  resource_id        = aws_appautoscaling_target.portal[count.index].resource_id
+  scalable_dimension = aws_appautoscaling_target.portal[count.index].scalable_dimension
 
   target_tracking_scaling_policy_configuration {
     scale_in_cooldown  = var.scale_in_cooldown
@@ -250,9 +250,9 @@ resource "aws_appautoscaling_policy" "portal_memory" {
   count              = var.portal_autoscale_enabled ? 1 : 0
   name               = "portal_memory"
   policy_type        = "TargetTrackingScaling"
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.covidportal.cluster}/${aws_ecs_service.covidportal.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = aws_appautoscaling_target.portal[count.index].service_namespace
+  resource_id        = aws_appautoscaling_target.portal[count.index].resource_id
+  scalable_dimension = aws_appautoscaling_target.portal[count.index].scalable_dimension
 
   target_tracking_scaling_policy_configuration {
     scale_in_cooldown  = var.scale_in_cooldown
@@ -267,7 +267,7 @@ resource "aws_appautoscaling_policy" "portal_memory" {
 resource "aws_appautoscaling_target" "qrcode" {
   count              = var.portal_autoscale_enabled ? 1 : 0
   service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.qrcode.cluster}/${aws_ecs_service.qrcode.name}"
+  resource_id        = "service/${aws_ecs_cluster.covidportal.name}/${aws_ecs_service.qrcode.name}"
   scalable_dimension = "ecs:service:DesiredCount"
   min_capacity       = var.min_capacity
   max_capacity       = var.max_capacity
@@ -276,9 +276,9 @@ resource "aws_appautoscaling_policy" "qrcode_cpu" {
   count              = var.portal_autoscale_enabled ? 1 : 0
   name               = "qrcode_cpu"
   policy_type        = "TargetTrackingScaling"
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.qrcode.cluster}/${aws_ecs_service.qrcode.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = aws_appautoscaling_target.qrcode[count.index].service_namespace
+  resource_id        = aws_appautoscaling_target.qrcode[count.index].resource_id
+  scalable_dimension = aws_appautoscaling_target.qrcode[count.index].scalable_dimension
 
   target_tracking_scaling_policy_configuration {
     scale_in_cooldown  = var.scale_in_cooldown
@@ -294,9 +294,9 @@ resource "aws_appautoscaling_policy" "qrcode_memory" {
   count              = var.portal_autoscale_enabled ? 1 : 0
   name               = "portal_memory"
   policy_type        = "TargetTrackingScaling"
-  service_namespace  = "ecs"
-  resource_id        = "service/${aws_ecs_service.qrcode.cluster}/${aws_ecs_service.qrcode.name}"
-  scalable_dimension = "ecs:service:DesiredCount"
+  service_namespace  = aws_appautoscaling_target.qrcode[count.index].service_namespace
+  resource_id        = aws_appautoscaling_target.qrcode[count.index].resource_id
+  scalable_dimension = aws_appautoscaling_target.qrcode[count.index].scalable_dimension
 
   target_tracking_scaling_policy_configuration {
     scale_in_cooldown  = var.scale_in_cooldown


### PR DESCRIPTION
# Summary
The format of the aws_appautoscaling_target `resource_id` was
incorrect, which stopped the autoscaling targets and polices
from being properly attached to the ECS services.

# Expected infra changes
* Recreate the autoscaling targets and policies for the portal and QR code ECS services.
