### PR TITLE
feat: add FARGATE capacity provider to ECS cluster

### DIFF
--- a/config/infrastructure/aws/appspec-template.json
+++ b/config/infrastructure/aws/appspec-template.json
@@ -10,7 +10,12 @@
                     "LoadBalancerInfo": {
                         "ContainerName": "placeholder",
                         "ContainerPort": 0
-                    }
+                    },
+                    "CapacityProviderStrategy": [{
+                        "CapacityProvider": "FARGATE",
+                        "Base": 2,
+                        "Weight": 1
+                    }]
                 }
             }
         }

--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -13,6 +13,12 @@ resource "aws_ecs_cluster" "covidportal" {
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 2
+  }
 }
 
 locals {
@@ -136,6 +142,13 @@ resource "aws_ecs_service" "covidportal" {
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 2
+  }
+
   deployment_controller {
     type = "CODE_DEPLOY"
   }
@@ -187,6 +200,13 @@ resource "aws_ecs_service" "qrcode" {
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 2
+  }
+
   deployment_controller {
     type = "CODE_DEPLOY"
   }


### PR DESCRIPTION
# Summary
This should allow the CodeDeploy blue/green deployment to autoscale the ECS tasks to meet CPU/memory demand.

# Expected infra changes
* Update ECS cluster with a default capacity provider of type `FARGATE`.
* Recreate the ECS portal and qrcode services with a capacity provider of type `FARGATE`.

Related #623 