### PR TITLE
feat: re-add FARGATE capacity provider to services

### DIFF
--- a/config/infrastructure/aws/appspec-template.json
+++ b/config/infrastructure/aws/appspec-template.json
@@ -11,7 +11,12 @@
                         "ContainerName": "placeholder",
                         "ContainerPort": 0
                     }
-                }
+                },
+                "CapacityProviderStrategy": [{
+                    "CapacityProvider": "FARGATE",
+                    "Weight": 1,
+                    "Base": 2                    
+                }]                
             }
         }
     ]

--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -10,6 +10,14 @@ resource "aws_ecs_cluster" "covidportal" {
     value = "enabled"
   }
 
+  capacity_providers = ["FARGATE"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 2
+  }
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }
@@ -155,6 +163,12 @@ resource "aws_ecs_service" "covidportal" {
     container_port   = 8000
   }
 
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 2
+  }  
+
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }
@@ -205,6 +219,12 @@ resource "aws_ecs_service" "qrcode" {
     container_name   = var.ecs_covid_portal_name
     container_port   = 8000
   }
+
+  capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+    base              = 2
+  }  
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value

--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -167,7 +167,7 @@ resource "aws_ecs_service" "covidportal" {
     capacity_provider = "FARGATE"
     weight            = 1
     base              = 2
-  }  
+  }
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
@@ -224,7 +224,7 @@ resource "aws_ecs_service" "qrcode" {
     capacity_provider = "FARGATE"
     weight            = 1
     base              = 2
-  }  
+  }
 
   tags = {
     (var.billing_tag_key) = var.billing_tag_value


### PR DESCRIPTION
# Summary
Now that the cluster capacity provider has been properly set, the services and CodeDeploy template can be updated as well.

# Note
The portal and QR code deploy jobs may fail as the `terraform apply` runs, and will need to be re-run.