### PR TITLE
fix: ECS service capacity provider and AppSpec template

### DIFF
--- a/config/infrastructure/aws/appspec-template.json
+++ b/config/infrastructure/aws/appspec-template.json
@@ -10,13 +10,13 @@
                     "LoadBalancerInfo": {
                         "ContainerName": "placeholder",
                         "ContainerPort": 0
-                    }
-                },
-                "CapacityProviderStrategy": [{
-                    "CapacityProvider": "FARGATE",
-                    "Weight": 1,
-                    "Base": 2                    
-                }]                
+                    },
+                    "CapacityProviderStrategy": [{
+                        "CapacityProvider": "FARGATE",
+                        "Weight": 1,
+                        "Base": 2
+                    }]
+                }
             }
         }
     ]

--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -163,12 +163,6 @@ resource "aws_ecs_service" "covidportal" {
     container_port   = 8000
   }
 
-  capacity_provider_strategy {
-    capacity_provider = "FARGATE"
-    weight            = 1
-    base              = 2
-  }
-
   tags = {
     (var.billing_tag_key) = var.billing_tag_value
   }
@@ -218,12 +212,6 @@ resource "aws_ecs_service" "qrcode" {
     target_group_arn = aws_lb_target_group.qrcode.arn
     container_name   = var.ecs_covid_portal_name
     container_port   = 8000
-  }
-
-  capacity_provider_strategy {
-    capacity_provider = "FARGATE"
-    weight            = 1
-    base              = 2
   }
 
   tags = {


### PR DESCRIPTION
# Summary
* ECS services do not support both the `launch_type` and `capacity_provider_strategy` block.
* The CodeDeploy AppSpec template needs the `CapacityProviderStrategy` block to be part of the `Properties` object.