### PR TITLE
feat: lower CPU scale metric on ECS

### DIFF
--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -300,7 +300,7 @@ resource "aws_appautoscaling_policy" "qrcode_cpu" {
 
 resource "aws_appautoscaling_policy" "qrcode_memory" {
   count              = var.portal_autoscale_enabled ? 1 : 0
-  name               = "portal_memory"
+  name               = "qrcode_memory"
   policy_type        = "TargetTrackingScaling"
   service_namespace  = aws_appautoscaling_target.qrcode[count.index].service_namespace
   resource_id        = aws_appautoscaling_target.qrcode[count.index].resource_id

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -54,7 +54,7 @@ variable "scale_out_cooldown" {
 }
 variable "cpu_scale_metric" {
   type    = number
-  default = 60
+  default = 20
 }
 variable "memory_scale_metric" {
   type    = number


### PR DESCRIPTION
Even under heavy load, ECS does not get to the 60% CPU threshold.
Also renames the QR code scaling policy for consistency.