### PR TITLE
Fix/french abbrev fix

### DIFF
--- a/profiles/static/js/datepicker.js
+++ b/profiles/static/js/datepicker.js
@@ -38,8 +38,8 @@ Array.apply(null,pickers).forEach(function(picker) {
               "septembre", "octobre", "novembre", "décembre"
             ],
             monthNamesShort: [
-              "janv", "févr", "mars", "avril", "mai", "juin",
-              "juil", "août", "sept", "oct", "nov", "déc"
+              "janv.", "févr.", "mars", "avr.", "mai", "juin",
+              "juill.", "août", "sept.", "oct.", "nov.", "déc."
             ],
             locale: "ca-FR",
         }

--- a/profiles/static/js/datepicker.js
+++ b/profiles/static/js/datepicker.js
@@ -38,8 +38,8 @@ Array.apply(null,pickers).forEach(function(picker) {
               "septembre", "octobre", "novembre", "décembre"
             ],
             monthNamesShort: [
-              "janv.", "févr.", "mars", "avr.", "mai", "juin",
-              "juill.", "août", "sept.", "oct.", "nov.", "déc."
+              "janv", "févr", "mars", "avr", "mai", "juin",
+              "juill", "août", "sept", "oct", "nov", "déc"
             ],
             locale: "ca-FR",
         }


### PR DESCRIPTION
###  Summary | Résumé

Fixing up french abbreviations in the date picker. Details of the issue and Trello ticket can be found here:

https://trello.com/c/1Scu9WcN/842-fix-abbreviation-for-months-french-only


### Testing
Make sure you hard reload the webpage when testing this feature as to not cache the date picker. For example, use Shift + Command + R if you are using Chrome.