### PR TITLE
fix: adjust workflow Terraform triggers

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -4,9 +4,13 @@ on:
   push:
     branches:
       - main
+    paths:
+      - "config/**"
+      - ".github/workflows/terraform.yml"
   pull_request:
     paths:
-      - "config/terraform/aws/*"
+      - "config/**"
+      - ".github/workflows/terraform.yml"
 
 defaults:
   run:


### PR DESCRIPTION
# Summary | Résumé
This fixes a bug where the Terraform workflow would run on every push to `main`.

The Terraform workflow should only run when there are changes to the config directory and the `terraform.yml` workflow.

# Note
This will re-enable the `PostRequestLimit` WAF rule, so we'll have to manually disable that again for the load testing.