### PR TITLE
Reordering QR code and instructions in poster

### DIFF
--- a/register/utils.py
+++ b/register/utils.py
@@ -126,8 +126,8 @@ def get_pdf_poster(location, lang="en"):
 
     # Merge the pdfs
     mergeFile = PyPDF2.PdfFileMerger()
-    mergeFile.append(buffer)
     mergeFile.append(pdf_instructions)
+    mergeFile.append(buffer)
 
     # Write it back to the puffer
     mergeFile.write(buffer)


### PR DESCRIPTION

###  Summary | Résumé

Reordered the instructions and qr code in the poster generated by the Registration site. Now the instructions appear first followed by the QR code.  