### PR TITLE
Return an empty string on missing registrant model

### DIFF
--- a/register/models.py
+++ b/register/models.py
@@ -54,7 +54,7 @@ class Location(models.Model):
 
     @property
     def registrant_email(self):
-        return self.registrant.email
+        return self.registrant.email or ''
 
     # Override save method to generate a unique short code for poster
     def save(self, *args, **kwargs):

--- a/register/models.py
+++ b/register/models.py
@@ -54,7 +54,7 @@ class Location(models.Model):
 
     @property
     def registrant_email(self):
-        return self.registrant.email or ''
+        return self.registrant.email or ""
 
     # Override save method to generate a unique short code for poster
     def save(self, *args, **kwargs):


### PR DESCRIPTION
# Summary | Résumé

This shouldn't be possible, but somehow on Staging a Registrant has been deleted, orphaning its Locations. This is now causing an error on the Admin/Locations view because of the missing model - the Location model tries to populate registrant_email from the related model which no longer exists.

This just returns an empty string in that case.