### PR TITLE
feat: lower ECS CPU/memory autoscale thresholds

### DIFF
--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -50,15 +50,15 @@ variable "scale_in_cooldown" {
 }
 variable "scale_out_cooldown" {
   type    = number
-  default = 60
+  default = 10
 }
 variable "cpu_scale_metric" {
   type    = number
-  default = 20
+  default = 15
 }
 variable "memory_scale_metric" {
   type    = number
-  default = 60
+  default = 10
 }
 variable "min_capacity" {
   type    = number


### PR DESCRIPTION
# Summary
* Decreases CPU and memory threshold before a scale event occurs.
* Also decreases time between scale-out events to allow the site to more quickly adapt to load spikes.

# Expected changes
* Update the ECS autoscale policies with the new values.