### PR TITLE
Bugfix - don't include lang when looking up registrant

### DIFF
--- a/register/views.py
+++ b/register/views.py
@@ -94,8 +94,9 @@ def confirm_email(request, pk):
         # Create the Registrant
         registrant, created = Registrant.objects.get_or_create(email=confirm.email)
 
-        registrant.language_cd = request.LANGUAGE_CODE or "en"
-        registrant.save()
+        if (registrant.language_cd != request.LANGUAGE_CODE):
+            registrant.language_cd = request.LANGUAGE_CODE
+            registrant.save()
 
         # Save to session
         request.session["registrant_id"] = str(registrant.id)

--- a/register/views.py
+++ b/register/views.py
@@ -92,9 +92,7 @@ def confirm_email(request, pk):
             return redirect(reverse_lazy("register:confirm_email_error"))
 
         # Create the Registrant
-        registrant, created = Registrant.objects.get_or_create(
-            email=confirm.email
-        )
+        registrant, created = Registrant.objects.get_or_create(email=confirm.email)
 
         registrant.language_cd = request.LANGUAGE_CODE or "en"
         registrant.save()

--- a/register/views.py
+++ b/register/views.py
@@ -93,8 +93,11 @@ def confirm_email(request, pk):
 
         # Create the Registrant
         registrant, created = Registrant.objects.get_or_create(
-            email=confirm.email, language_cd=request.LANGUAGE_CODE or "en"
+            email=confirm.email
         )
+
+        registrant.language_cd = request.LANGUAGE_CODE or "en"
+        registrant.save()
 
         # Save to session
         request.session["registrant_id"] = str(registrant.id)

--- a/register/views.py
+++ b/register/views.py
@@ -94,7 +94,7 @@ def confirm_email(request, pk):
         # Create the Registrant
         registrant, created = Registrant.objects.get_or_create(email=confirm.email)
 
-        if (registrant.language_cd != request.LANGUAGE_CODE):
+        if registrant.language_cd != request.LANGUAGE_CODE:
             registrant.language_cd = request.LANGUAGE_CODE
             registrant.save()
 


### PR DESCRIPTION
# Summary | Résumé

This fixes an issue introduced in a recent PR. The language was added to the get_or_create on Registrant creation. Problem being if someone switches languages, the lookup won't return their previous Registrant model, and then the create fails due to a unique constraint on email. 

This just separates out the language setting to happen after retrieving or creating the Registrant record.

## To test
- Register/confirm with your interface in English
- Check the database and notice your language property set
- Register again with the same email but your interface in French
- Check the database and notice your language has been changed