### PR TITLE
Render month names in French

### DIFF
--- a/outbreaks/forms.py
+++ b/outbreaks/forms.py
@@ -54,7 +54,7 @@ for hour in range(24):
     end_hours.append(display_hour_29)
     end_hours.append(display_hour_59)
 
-month_choices = [(i + 1, month_name[i + 1]) for i in range(12)]
+month_choices = [(i + 1, _(month_name[i + 1])) for i in range(12)]
 month_choices.insert(0, (-1, _("Select")))
 
 


### PR DESCRIPTION
# Summary | Résumé

Discovered this bug when reviewing a related PR.

Month names in the Select list were showing up in English on the French interface.

| Old | New |
| ---- | ---- |
| ![image](https://user-images.githubusercontent.com/1187115/123163862-39580f80-d440-11eb-9f61-eb1278784d1f.png) | ![image](https://user-images.githubusercontent.com/1187115/123163916-4bd24900-d440-11eb-89e1-28a4ef104e77.png) |

## To test
- Navigate to the datetime screen in French
- Observe the French month names