### PR TITLE
add location to ensure join on query when sorting by date

### DIFF
--- a/outbreaks/views.py
+++ b/outbreaks/views.py
@@ -607,7 +607,9 @@ class HistoryView(SearchListBaseView):
             return qs.order_by(col if order == "asc" else col.desc())
         else:
             col = "start_date"
-            return qs.order_by(col if order == "asc" else f"-{col}", Lower("location__name"))
+            return qs.order_by(
+                col if order == "asc" else f"-{col}", Lower("location__name")
+            )
 
 
 class ExposureDetailsView(PermissionRequiredMixin, Is2FAMixin, TemplateView):

--- a/outbreaks/views.py
+++ b/outbreaks/views.py
@@ -607,7 +607,7 @@ class HistoryView(SearchListBaseView):
             return qs.order_by(col if order == "asc" else col.desc())
         else:
             col = "start_date"
-            return qs.order_by(col if order == "asc" else f"-{col}")
+            return qs.order_by(col if order == "asc" else f"-{col}", Lower("location__name"))
 
 
 class ExposureDetailsView(PermissionRequiredMixin, Is2FAMixin, TemplateView):


### PR DESCRIPTION
# Summary | Résumé

Trello
https://trello.com/c/x9hELaXd/831-sort-search-results-on-the-alerts-history

Join was missing from generated SQL when sorting by date only, added location->name to force inner join when sorting by date.

# Test instructions | Instructions pour tester la modification

Sort by date on alert history, search results should remain as expected with no additional entries.
