### PR TITLE
feat: split portal/qrcode scaling min/max capacity

### DIFF
--- a/config/terraform/aws/ecs.tf
+++ b/config/terraform/aws/ecs.tf
@@ -140,7 +140,7 @@ resource "aws_ecs_service" "covidportal" {
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
-  desired_count                      = 2
+  desired_count                      = var.min_capacity_portal
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60
@@ -191,7 +191,7 @@ resource "aws_ecs_service" "qrcode" {
   # Enable the new ARN format to propagate tags to containers (see config/terraform/aws/README.md)
   propagate_tags = "SERVICE"
 
-  desired_count                      = 2
+  desired_count                      = var.min_capacity_qrcode
   deployment_minimum_healthy_percent = 50
   deployment_maximum_percent         = 200
   health_check_grace_period_seconds  = 60
@@ -233,8 +233,8 @@ resource "aws_appautoscaling_target" "portal" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.covidportal.name}/${aws_ecs_service.covidportal.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = var.min_capacity
-  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity_portal
+  max_capacity       = var.max_capacity_portal
 }
 resource "aws_appautoscaling_policy" "portal_cpu" {
   count              = var.portal_autoscale_enabled ? 1 : 0
@@ -277,8 +277,8 @@ resource "aws_appautoscaling_target" "qrcode" {
   service_namespace  = "ecs"
   resource_id        = "service/${aws_ecs_cluster.covidportal.name}/${aws_ecs_service.qrcode.name}"
   scalable_dimension = "ecs:service:DesiredCount"
-  min_capacity       = var.min_capacity
-  max_capacity       = var.max_capacity
+  min_capacity       = var.min_capacity_qrcode
+  max_capacity       = var.max_capacity_qrcode
 }
 resource "aws_appautoscaling_policy" "qrcode_cpu" {
   count              = var.portal_autoscale_enabled ? 1 : 0

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -50,21 +50,29 @@ variable "scale_in_cooldown" {
 }
 variable "scale_out_cooldown" {
   type    = number
-  default = 10
+  default = 60
 }
 variable "cpu_scale_metric" {
   type    = number
-  default = 15
+  default = 10
 }
 variable "memory_scale_metric" {
   type    = number
   default = 10
 }
-variable "min_capacity" {
+variable "min_capacity_portal" {
   type    = number
   default = 2
 }
-variable "max_capacity" {
+variable "max_capacity_portal" {
+  type    = number
+  default = 10
+}
+variable "min_capacity_qrcode" {
+  type    = number
+  default = 4
+}
+variable "max_capacity_qrcode" {
   type    = number
   default = 10
 }


### PR DESCRIPTION
# Summary 
This allows the portal and QR code services to independently set
minimum and maximum scale capacities.

Also sets scale-out cool down back to 60 seconds as the CPU
metric is only captured every 60 seconds, so having a value
lower than this causes inconsistent scaling.

# Changes
* Update autoscaling targets with lowered CPU threshold.
* Update QR code autoscaling target with new min capacity of `4`.
* Recreate the QR code WAF POST limit rule (I'll take care of removing after the `tf apply`).