### PR TITLE
Modifying OTK-flow as per git issue #604

### DIFF
--- a/covid_key/templates/covid_key/otk_start.html
+++ b/covid_key/templates/covid_key/otk_start.html
@@ -1,7 +1,13 @@
 {% extends 'base.html' %}
 {% load i18n %}
 
-{% block title %}{% trans "You’re logged in to give one-time keys" %}{% endblock %}
+{% block title %}
+  {% if request.user.can_send_alerts %}
+    {% trans "Now you can give one-time keys" %}
+  {% else %}
+    {% trans "You’re logged in to give one-time keys" %}
+  {% endif %}
+{% endblock %}
 
 {% block content %}
   {% if request.user.can_send_alerts %}

--- a/covid_key/templates/covid_key/otk_start.html
+++ b/covid_key/templates/covid_key/otk_start.html
@@ -4,7 +4,11 @@
 {% block title %}{% trans "You’re logged in to give one-time keys" %}{% endblock %}
 
 {% block content %}
-  <h1>{% trans "You’re logged in to give one-time keys" %}</h1>
+  {% if request.user.can_send_alerts %}
+    <h1>{% trans "Now you can give one-time keys" %}</h1>
+  {% else %}
+    <h1>{% trans "You’re logged in to give one-time keys" %}</h1>
+  {% endif %}
   <p>
     {% trans "People need a key if they’ve:" %}
   </p>


### PR DESCRIPTION
# Summary | Résumé

Modifying otk-flow as specified in github issue #604 

## Test instructions | Instructions pour tester la modification
Testing this feature can be a little bit tricky. There could have been a better way to do it (ie modifying the request object using the developer tools), but I wanted to replicate exactly how the flow will be executed.

1. To test the "Now you can you give one-time keys" message, log in as an admin user and go to the landing page. You should see "Give one time keys" and if you click that box, the next message should be "Now you can give one time keys".

2. To test the "You are logged in to give one time keys", login as a staff user (or create one if you don't have one). If you log in as a staff user, the message you should see is "You are logged in to give one time keys" 
