### PR TITLE
feat: add Terraform plan GitHub action

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -47,17 +47,14 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_version: 0.13.1
-
-      - name: Terraform Init
-        run: |
-          terraform init
-      - name: Terraform Format
-        run: terraform fmt -check
+          terraform_wrapper: false
 
       - name: Terraform Plan
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: terraform plan
+        uses: cds-snc/terraform-plan@v1.0.5
+        with:
+          comment-delete: true
+          directory: ./config/terraform/aws
+          github-token: ${{ secrets.GITHUB_TOKEN }}
 
   terraform-security-scan:
     if: github.ref != 'refs/heads/main'

--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -56,7 +56,7 @@ resource "aws_cloudfront_distribution" "maintenance_mode" {
   }
   viewer_certificate {
     acm_certificate_arn      = aws_acm_certificate_validation.cert.certificate_arn
-    minimum_protocol_version = "TLSv1.2_2019"
+    minimum_protocol_version = "TLSv1.2_2021"
     ssl_support_method       = "sni-only"
   }
 

--- a/config/terraform/aws/ecr.tf
+++ b/config/terraform/aws/ecr.tf
@@ -2,7 +2,7 @@ locals {
   image_name = "covid-alert-portal-terraform"
 }
 
-#tfsec:ignore:AWS078
+#tfsec:ignore:AWS078 tfsec:ignore:AWS093
 resource "aws_ecr_repository" "repository" {
   name                 = local.image_name
   image_tag_mutability = "MUTABLE"

--- a/config/terraform/aws/secrets.tf
+++ b/config/terraform/aws/secrets.tf
@@ -1,3 +1,4 @@
+# tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "server_database_url" {
   name                    = "server-database-url"
   recovery_window_in_days = 0
@@ -12,6 +13,7 @@ resource "aws_secretsmanager_secret_version" "server_database_url" {
 # AWS Secret Manager - Covid Alert Portal
 ###
 
+# tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "api_authorization" {
   name                    = "api_authorization"
   recovery_window_in_days = 0
@@ -22,6 +24,7 @@ resource "aws_secretsmanager_secret_version" "api_authorization" {
   secret_string = var.ecs_secret_api_authorization
 }
 
+# tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "api_endpoint" {
   name                    = "api_endpoint"
   recovery_window_in_days = 0
@@ -32,6 +35,7 @@ resource "aws_secretsmanager_secret_version" "api_endpoint" {
   secret_string = var.ecs_secret_api_endpoint
 }
 
+# tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "django_secret_key" {
   name                    = "django_secret_key"
   recovery_window_in_days = 0
@@ -42,6 +46,7 @@ resource "aws_secretsmanager_secret_version" "django_secret_key" {
   secret_string = var.ecs_secret_django_secret_key
 }
 
+# tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "freshdesk_api_endpoint" {
   name                    = "freshdesk_api_endpoint"
   recovery_window_in_days = 0
@@ -52,6 +57,7 @@ resource "aws_secretsmanager_secret_version" "freshdesk_api_endpoint" {
   secret_string = var.ecs_secret_freshdesk_api_endpoint
 }
 
+# tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "freshdesk_api_key" {
   name                    = "freshdesk_api_key"
   recovery_window_in_days = 0
@@ -62,6 +68,7 @@ resource "aws_secretsmanager_secret_version" "freshdesk_api_key" {
   secret_string = var.ecs_secret_freshdesk_api_key
 }
 
+# tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "freshdesk_product_id" {
   name                    = "freshdesk_product_id"
   recovery_window_in_days = 0
@@ -72,6 +79,7 @@ resource "aws_secretsmanager_secret_version" "freshdesk_product_id" {
   secret_string = var.ecs_secret_freshdesk_product_id
 }
 
+# tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "new_relic_license_key" {
   name                    = "new_relic_license_key"
   recovery_window_in_days = 0
@@ -82,6 +90,7 @@ resource "aws_secretsmanager_secret_version" "new_relic_license_key" {
   secret_string = var.ecs_secret_new_relic_license_key
 }
 
+# tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "notify_api_key" {
   name                    = "notify_api_key"
   recovery_window_in_days = 0
@@ -92,6 +101,7 @@ resource "aws_secretsmanager_secret_version" "notify_api_key" {
   secret_string = var.ecs_secret_notify_api_key
 }
 
+# tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "qrcode_signature_private_key" {
   name                    = "qrcode_signature_private_key"
   recovery_window_in_days = 0
@@ -102,6 +112,7 @@ resource "aws_secretsmanager_secret_version" "qrcode_signature_private_key" {
   secret_string = var.ecs_secret_qrcode_signature_private_key
 }
 
+# tfsec:ignore:AWS095
 resource "aws_secretsmanager_secret" "qrcode_notify_api_key" {
   name                    = "qrcode_notify_api_key"
   recovery_window_in_days = 0


### PR DESCRIPTION
# Summary
* Switches to the Terraform plan GitHub action for `*.tf` validation and plans.
* Adds `tfsec:ignore` comments for key encryption Terraform security failures.
* Updates CloudFront maintenance distribution minimum TLS protocol. 

# Note
After this merges, I'll revert the WAF infra changes we've got setup for load testing.