### PR TITLE
feat: add WAF geolocation block custom response

### DIFF
--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -315,7 +315,15 @@ resource "aws_wafv2_web_acl" "qrcode_acl" {
     priority = 5
 
     action {
-      block {}
+      block {
+        custom_response {
+          response_code = 403
+          response_header {
+            name  = "waf-block"
+            value = "CanadaOnlyGeoRestriction"
+          }
+        }
+      }
     }
 
     statement {


### PR DESCRIPTION
# Summary
This will be used to add the custom 403 page when the `CanadaOnlyGeoRestriction` WAF rule blocks a request.

# Expected change
* Update `CanadaOnlyGeoRestriction` WAF rule with custom response.