### PR TITLE
Modify uwsgi threads/workers config

### DIFF
--- a/config/terraform/aws/lb_qrcode.tf
+++ b/config/terraform/aws/lb_qrcode.tf
@@ -12,13 +12,13 @@ resource "aws_lb_target_group" "qrcode" {
 
   health_check {
     enabled             = true
-    interval            = 10
+    interval            = 15
     path                = "/status/"
     port                = 8000
     matcher             = "301,200"
     timeout             = 5
     healthy_threshold   = 2
-    unhealthy_threshold = 2
+    unhealthy_threshold = 10
   }
 
   tags = {
@@ -37,13 +37,13 @@ resource "aws_lb_target_group" "qrcode_2" {
 
   health_check {
     enabled             = true
-    interval            = 10
+    interval            = 15
     port                = 8000
     path                = "/status/"
     matcher             = "301,200"
     timeout             = 5
     healthy_threshold   = 2
-    unhealthy_threshold = 2
+    unhealthy_threshold = 10
   }
 
   tags = {

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,5 +21,5 @@ echo "Starting server"
 if [[ ${DJANGO_ENV} == 'development' ]]; then
 	python manage.py runserver 0.0.0.0:8000
 else
-	uwsgi --http :8000 --master --module portal.wsgi --static-map /static=/code/staticfiles --enable-threads --processes 10
+	uwsgi ./uwsgi.ini
 fi

--- a/uwsgi.ini
+++ b/uwsgi.ini
@@ -1,0 +1,22 @@
+[uwsgi]
+http = :8000
+module = portal.wsgi
+master = true
+enable-threads = True
+threads = 2
+static-map = /static=/code/staticfiles
+
+# Worker config
+cheaper-algo = spare
+
+# minimum number of workers to keep at all times
+cheaper = 5
+
+# number of workers to spawn at startup
+cheaper-initial = 5
+
+# maximum number of workers that can be spawned
+workers = 20
+
+# how many workers should be spawned at a time
+cheaper-step = 5


### PR DESCRIPTION
# Summary | Résumé

- Breaks uwsgi config into .ini file for better readability
- Modifies threads/worker config to hopefully handle load better
- Increases unhealthy threshold and interval for Load Balancer health checks

The thinking here is that we know error rates were reduced significantly when adding workers. Adding workers also increased memory usage, so we ended up over the autoscale threshold and the service was permanently scaled up. Adding the worker scaling (cheaper config) should alleviate this as the task will start with a small number of workers and scale up under load.

We also know the Load Balancer is killing the ecs task because it sees it as unhealthy because it can't reach the health check. Setting the health check interval a bit longer and increasing the number of failed checks that would trigger an unhealthy status should give the task a bit of breathing room.