### PR TITLE
Changing the Send alert button to green instead of yellow

### DIFF
--- a/outbreaks/templates/confirm.html
+++ b/outbreaks/templates/confirm.html
@@ -73,6 +73,6 @@
   </div>
 
   {% url 'outbreaks:search' as outbreaks_search_url %}
-  {% include "includes/cds_form.html" with submit_text=_("Send alert") submit_class='warning' secondary_action_after=True secondary_action_text=_('Cancel this exposure') secondary_action_url=outbreaks_search_url %}
+  {% include "includes/cds_form.html" with submit_text=_("Send alert") submit_class='start with-chevron' secondary_action_after=True secondary_action_text=_('Cancel this exposure') secondary_action_url=outbreaks_search_url %}
 
 {% endblock %}


### PR DESCRIPTION
# Summary | Résumé

This corresponds to trello ticket: https://trello.com/c/Z6BxaVLW/876-send-alert-button-should-be-green-not-yellow

The send alert button is currently yellow, but instead it should be green as indicated in the trello card. 

## Test instructions | Instructions pour tester la modification
Go to Send Alerts and add a new exposure notification. When you go to the confirm screen before you send the alert, the "Send Alert" button should be green instead of yellow. 