### PR TITLE
fix: remove QR code DNS health check

### DIFF
--- a/config/terraform/aws/route53.tf
+++ b/config/terraform/aws/route53.tf
@@ -100,13 +100,3 @@ resource "aws_route53_record" "maintenance_qrcode" {
     evaluate_target_health = false
   }
 }
-
-# Route 53 Healthcheck
-resource "aws_route53_health_check" "dns-is-routeable-2" {
-  fqdn              = "register.${aws_route53_zone.covidportal.name}"
-  port              = 443
-  type              = "HTTPS"
-  resource_path     = "/status/"
-  failure_threshold = "5"
-  request_interval  = "30"
-}


### PR DESCRIPTION
# Summary
This will be replaced with an AWS CloudWatch Synthetic monitor because the Canada-only geolocation WAF rule blocks the Route53 DNS health checkers.

# Expected change
Remove QR code health check.

Related #681 