### PR TITLE
Fix/send alert menu fix

### DIFF
--- a/portal/templates/includes/nav_main.html
+++ b/portal/templates/includes/nav_main.html
@@ -11,7 +11,7 @@
       {% endif %}
       {% switch "qr_codes" %}
         {% if perms.profiles.can_send_alerts and user.is_verified %}
-          <li><a {% if request.resolver_match.url_name == 'search' or request.resolver_match.url_name == 'history' or request.resolver_match.url_name == 'profile' or request.resolver_match.url_name == 'datetime' or request.resolver_match.url_name == 'severity' or request.resolver_match.url_name == 'confirm' or request.resolver_match.url_name == 'confirmed' %}class="active"{% endif %} href="{% url 'outbreaks:search' %}">{% trans "Send alerts" %}</a></li>
+          <li><a {% if request.resolver_match.url_name == 'search' or request.resolver_match.url_name == 'history' or request.resolver_match.url_name == 'profile' or request.resolver_match.url_name == 'details' or request.resolver_match.url_name == 'datetime' or request.resolver_match.url_name == 'severity' or request.resolver_match.url_name == 'confirm' or request.resolver_match.url_name == 'confirmed' %}class="active"{% endif %} href="{% url 'outbreaks:search' %}">{% trans "Send alerts" %}</a></li>
         {% endif %}
       {% endswitch %}
       {% if user.is_admin and user.is_verified %}

--- a/portal/templates/includes/nav_main.html
+++ b/portal/templates/includes/nav_main.html
@@ -15,7 +15,7 @@
         {% endif %}
       {% endswitch %}
       {% if user.is_admin and user.is_verified %}
-        <li><a {% if request.resolver_match.url_name == 'profiles' or request.resolver_match.url_name == 'invite' or request.resolver_match.url_name == 'healthcareuser' %}class="active"{% endif %} href="{% url 'profiles' %}">{% trans "Manage team" %}</a></li>
+        <li><a {% if request.resolver_match.url_name == 'profiles' or request.resolver_match.url_name == 'invite' %}class="active"{% endif %} href="{% url 'profiles' %}">{% trans "Manage team" %}</a></li>
       {% endif %}
       {% if not user.is_verified %}
         <li><a href="{% url 'about:index' %}">{% trans "About the portal" %}</a></li>

--- a/portal/templates/includes/nav_main.html
+++ b/portal/templates/includes/nav_main.html
@@ -1,6 +1,6 @@
 {% load i18n waffle_tags %}
 
-<nav class="nav--main"  aria-label="{% trans 'Product navigation' %}">
+<nav class="nav--main" aria-label="{% trans 'Product navigation' %}">
   <div class="page--container">
     <ul>
       {% if user.is_verified %}

--- a/portal/templates/includes/nav_main.html
+++ b/portal/templates/includes/nav_main.html
@@ -11,7 +11,7 @@
       {% endif %}
       {% switch "qr_codes" %}
         {% if perms.profiles.can_send_alerts and user.is_verified %}
-          <li><a {% if request.resolver_match.url_name == 'search' or request.resolver_match.url_name == 'history' or request.resolver_match.url_name == 'profile' or request.resolver_match.url_name == 'details' or request.resolver_match.url_name == 'datetime' or request.resolver_match.url_name == 'severity' or request.resolver_match.url_name == 'confirm' or request.resolver_match.url_name == 'confirmed' %}class="active"{% endif %} href="{% url 'outbreaks:search' %}">{% trans "Send alerts" %}</a></li>
+          <li><a {% if request.resolver_match.namespace == "outbreaks" %}class="active"{% endif %} href="{% url 'outbreaks:search' %}">{% trans "Send alerts" %}</a></li>
         {% endif %}
       {% endswitch %}
       {% if user.is_admin and user.is_verified %}

--- a/portal/templates/includes/nav_main.html
+++ b/portal/templates/includes/nav_main.html
@@ -7,15 +7,15 @@
         {% if perms.profiles.can_send_alerts%}
         <li><a {% if request.resolver_match.url_name == 'start' %}class="active"{% endif %} href="{% url 'start' %}">{% trans "Home" %}</a></li>
         {% endif %}
-        <li><a {% if request.resolver_match.url_name == 'otk_start' or request.resolver_match.url_name == 'generate_key' %}class="active"{% endif %} href="{% url 'otk_start' %}">{% trans "Generate keys" %}</a></li>
+        <li><a {% if request.resolver_match.url_name == 'otk_start' or request.resolver_match.url_name == 'generate_key' or request.resolver_match.url_name == 'key' %}class="active"{% endif %} href="{% url 'otk_start' %}">{% trans "Generate keys" %}</a></li>
       {% endif %}
       {% switch "qr_codes" %}
         {% if perms.profiles.can_send_alerts and user.is_verified %}
-          <li><a {% if request.resolver_match.url_name == 'search' %}class="active"{% endif %} href="{% url 'outbreaks:search' %}">{% trans "Send alerts" %}</a></li>
+          <li><a {% if request.resolver_match.url_name == 'search' or request.resolver_match.url_name == 'history' or request.resolver_match.url_name == 'profile' or request.resolver_match.url_name == 'datetime' or request.resolver_match.url_name == 'severity' or request.resolver_match.url_name == 'confirm' or request.resolver_match.url_name == 'confirmed' %}class="active"{% endif %} href="{% url 'outbreaks:search' %}">{% trans "Send alerts" %}</a></li>
         {% endif %}
       {% endswitch %}
       {% if user.is_admin and user.is_verified %}
-        <li><a {% if request.resolver_match.url_name == 'profiles' %}class="active"{% endif %} href="{% url 'profiles' %}">{% trans "Manage team" %}</a></li>
+        <li><a {% if request.resolver_match.url_name == 'profiles' or request.resolver_match.url_name == 'invite' or request.resolver_match.url_name == 'healthcareuser' %}class="active"{% endif %} href="{% url 'profiles' %}">{% trans "Manage team" %}</a></li>
       {% endif %}
       {% if not user.is_verified %}
         <li><a href="{% url 'about:index' %}">{% trans "About the portal" %}</a></li>


### PR DESCRIPTION
# Summary | Résumé

This is associated with Trello ticket: https://trello.com/c/RcQSBjMa/874-send-alerts-top-menu-should-be-selected-when-user-is-within-that-section-of-the-portal

Essentially when you go through the send alert flow, the Send Alert menu option is no longer highlighted to indicate where you are. I also fixed that for the Generate key flow and for the Manage team where ever I saw it. 


## Test instructions | Instructions pour tester la modification
Go through the Send Alerts flow and you will see that throughout the whole process, the Send alerts menu option is highlighted. 
