### PR TITLE
feat: enable AWS Shield for QR code

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -50,7 +50,7 @@ jobs:
           terraform_wrapper: false
 
       - name: Terraform Plan
-        uses: cds-snc/terraform-plan@v1.0.5
+        uses: cds-snc/terraform-plan@v1
         with:
           comment-delete: true
           directory: ./config/terraform/aws

--- a/config/terraform/aws/shield.tf
+++ b/config/terraform/aws/shield.tf
@@ -9,3 +9,8 @@ resource "aws_shield_protection" "alb_covidportal" {
   name         = "alb_covidportal"
   resource_arn = aws_lb.covidportal.arn
 }
+
+resource "aws_shield_protection" "alb_qrcode" {
+  name         = "alb_qrcode"
+  resource_arn = aws_lb.qrcode.arn
+}


### PR DESCRIPTION
# Summary
Adding AWS Shield to the QR code load balancer in preparation for the CloudFront change.  The goal is to minimize the differences between staging/prod so that there are no surprises when the QR code CloudFront distribution is being tested.

Also bumps the Terraform plan action to the v1 tag so non-breaking releases of the action are automatically picked up by the workflow.

# Expected change
Add Shield to the QR code load balancer.