### PR TITLE
feat: add CloudFront to QR code site

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -66,15 +66,12 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Remove .tfvars
-        run: |
-          # Workaround for https://github.com/aquasecurity/tfsec-pr-commenter-action/issues/11
-          rm ./config/terraform/aws/variables.auto.tfvars
+        run: rm variables.auto.tfvars
 
       - name: Terraform security scan
         uses: aquasecurity/tfsec-pr-commenter-action@89c691a931c555965b3f2c85857f7aa08980e311 # v0.1.7
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}        
-          working_directory: ./config/terraform/aws
+          github_token: ${{ secrets.GITHUB_TOKEN }}
 
   terraform-apply:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -33,6 +33,7 @@ env:
   TF_VAR_slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
   TF_VAR_ecs_secret_qrcode_signature_private_key: ${{ secrets.QRCODE_SIGNATURE_PRIVATE_KEY }}
   TF_VAR_ecs_secret_qrcode_notify_api_key: ${{ secrets.QRCODE_NOTIFY_API_KEY }}
+  TF_VAR_cloudfront_qrcode_custom_header: ${{ secrets.CLOUDFRONT_QRCODE_CUSTOM_HEADER }}
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -64,12 +64,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+
       - name: Terraform security scan
-        uses: triat/terraform-security-scan@v2.2.3
+        uses: aquasecurity/tfsec-pr-commenter-action@89c691a931c555965b3f2c85857f7aa08980e311 # v0.1.7
         with:
-          tfsec_actions_working_dir: ./config/terraform/aws
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}        
+          working_directory: ./config/terraform/aws
 
   terraform-apply:
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Remove .tfvars
+        run: |
+          # Workaround for https://github.com/aquasecurity/tfsec-pr-commenter-action/issues/11
+          rm ./config/terraform/aws/variables.auto.tfvars
+
       - name: Terraform security scan
         uses: aquasecurity/tfsec-pr-commenter-action@89c691a931c555965b3f2c85857f7aa08980e311 # v0.1.7
         with:

--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -55,7 +55,7 @@ resource "aws_cloudfront_distribution" "maintenance_mode" {
     }
   }
   viewer_certificate {
-    acm_certificate_arn      = aws_acm_certificate.covidportal_certificate.arn
+    acm_certificate_arn      = aws_acm_certificate_validation.cert.certificate_arn
     minimum_protocol_version = "TLSv1.2_2021"
     ssl_support_method       = "sni-only"
   }
@@ -149,7 +149,7 @@ resource "aws_cloudfront_distribution" "qrcode" {
   }
 
   viewer_certificate {
-    acm_certificate_arn      = aws_acm_certificate.covidportal_certificate.arn
+    acm_certificate_arn      = aws_acm_certificate_validation.cert.certificate_arn
     minimum_protocol_version = "TLSv1.2_2021"
     ssl_support_method       = "sni-only"
   }

--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -95,10 +95,10 @@ resource "aws_cloudfront_distribution" "qrcode" {
 
   aliases = ["register.covid-hcportal.cdssandbox.xyz"]
 
-  # By default, cache nothing
+  # By default, cache nothing (controlled by TTL of 0)
   default_cache_behavior {
-    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
-    cached_methods   = []
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT", "DELETE"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = aws_lb.qrcode.name
 
     forwarded_values {
@@ -121,7 +121,7 @@ resource "aws_cloudfront_distribution" "qrcode" {
   ordered_cache_behavior {
     path_pattern     = "/static/*"
     allowed_methods  = ["GET", "HEAD", "OPTIONS"]
-    cached_methods   = ["GET", "HEAD"]
+    cached_methods   = ["GET", "HEAD", "OPTIONS"]
     target_origin_id = aws_lb.qrcode.name
 
     forwarded_values {
@@ -133,7 +133,7 @@ resource "aws_cloudfront_distribution" "qrcode" {
     }
 
     viewer_protocol_policy = "redirect-to-https"
-    min_ttl                = 604800
+    min_ttl                = 604800 # 1 week
     default_ttl            = 604800
     max_ttl                = 604800
     compress               = true

--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -55,12 +55,110 @@ resource "aws_cloudfront_distribution" "maintenance_mode" {
     }
   }
   viewer_certificate {
-    acm_certificate_arn      = aws_acm_certificate_validation.cert.certificate_arn
+    acm_certificate_arn      = aws_acm_certificate.covidportal_certificate.arn
     minimum_protocol_version = "TLSv1.2_2021"
     ssl_support_method       = "sni-only"
   }
 
+  price_class = "PriceClass_100"
+
   depends_on = [
     aws_s3_bucket.portal_maintenance_mode
   ]
+}
+
+###
+# AWS Cloudfront (CDN) - QR code
+###
+
+resource "aws_cloudfront_distribution" "qrcode" {
+  origin {
+    domain_name = aws_lb.qrcode.dns_name
+    origin_id   = aws_lb.qrcode.name
+
+    custom_header {
+      name  = "covidqrcode"
+      value = var.cloudfront_qrcode_custom_header
+    }
+
+    custom_origin_config {
+      http_port              = 80
+      https_port             = 443
+      origin_protocol_policy = "https-only"
+      origin_ssl_protocols   = ["TLSv1.2"]
+    }
+  }
+
+  enabled         = true
+  is_ipv6_enabled = true
+  web_acl_id      = aws_wafv2_web_acl.qrcode_cdn_acl.arn
+
+  aliases = ["register.covid-hcportal.cdssandbox.xyz"]
+
+  # Cache GET/HEAD respecting cache-control headers (min_ttl = 0)
+  default_cache_behavior {
+    allowed_methods  = ["GET", "HEAD", "OPTIONS", "POST"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = aws_lb.qrcode.name
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Referer"]
+      cookies {
+        forward = "all"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 0
+    default_ttl            = 3600
+    max_ttl                = 7200
+    compress               = true
+  }
+
+  # Cache `/static/*` assets for 1 week
+  # Cache busting has been added to the asset filenames to keep requests fresh
+  ordered_cache_behavior {
+    path_pattern     = "/static/*"
+    allowed_methods  = ["GET", "HEAD", "OPTIONS"]
+    cached_methods   = ["GET", "HEAD"]
+    target_origin_id = aws_lb.qrcode.name
+
+    forwarded_values {
+      query_string = true
+      headers      = ["Referer"]
+      cookies {
+        forward = "all"
+      }
+    }
+
+    viewer_protocol_policy = "redirect-to-https"
+    min_ttl                = 604800
+    default_ttl            = 604800
+    max_ttl                = 604800
+    compress               = true
+  }
+
+  price_class = "PriceClass_100"
+
+  restrictions {
+    geo_restriction {
+      restriction_type = "whitelist"
+      locations        = ["CA", "US"]
+    }
+  }
+
+  viewer_certificate {
+    acm_certificate_arn      = aws_acm_certificate.covidportal_certificate.arn
+    minimum_protocol_version = "TLSv1.2_2021"
+    ssl_support_method       = "sni-only"
+  }
+
+  logging_config {
+    include_cookies = false
+    bucket          = aws_s3_bucket.cloudfront_logs.bucket_domain_name
+    prefix          = "cloudfront"
+  }
+
+  depends_on = [aws_s3_bucket.cloudfront_logs]
 }

--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -95,10 +95,10 @@ resource "aws_cloudfront_distribution" "qrcode" {
 
   aliases = ["register.covid-hcportal.cdssandbox.xyz"]
 
-  # Cache GET/HEAD respecting cache-control headers (min_ttl = 0)
+  # By default, cache nothing
   default_cache_behavior {
     allowed_methods  = ["GET", "HEAD", "OPTIONS", "POST"]
-    cached_methods   = ["GET", "HEAD"]
+    cached_methods   = []
     target_origin_id = aws_lb.qrcode.name
 
     forwarded_values {
@@ -111,8 +111,8 @@ resource "aws_cloudfront_distribution" "qrcode" {
 
     viewer_protocol_policy = "redirect-to-https"
     min_ttl                = 0
-    default_ttl            = 3600
-    max_ttl                = 7200
+    default_ttl            = 0
+    max_ttl                = 0
     compress               = true
   }
 

--- a/config/terraform/aws/cloudfront.tf
+++ b/config/terraform/aws/cloudfront.tf
@@ -97,7 +97,7 @@ resource "aws_cloudfront_distribution" "qrcode" {
 
   # By default, cache nothing
   default_cache_behavior {
-    allowed_methods  = ["GET", "HEAD", "OPTIONS", "POST"]
+    allowed_methods  = ["DELETE", "GET", "HEAD", "OPTIONS", "PATCH", "POST", "PUT"]
     cached_methods   = []
     target_origin_id = aws_lb.qrcode.name
 

--- a/config/terraform/aws/kinesis.tf
+++ b/config/terraform/aws/kinesis.tf
@@ -87,3 +87,18 @@ resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs_qrcode" {
     bucket_arn = aws_s3_bucket.firehose_waf_logs_qrcode.arn
   }
 }
+
+resource "aws_kinesis_firehose_delivery_stream" "firehose_waf_logs_qrcode_cdn" {
+  provider = aws.us-east-1
+
+  name        = "aws-waf-logs-qrcode-cdn"
+  destination = "s3"
+  server_side_encryption {
+    enabled = true
+  }
+
+  s3_configuration {
+    role_arn   = aws_iam_role.firehose_waf_logs.arn
+    bucket_arn = aws_s3_bucket.firehose_waf_logs_qrcode.arn
+  }
+}

--- a/config/terraform/aws/route53.tf
+++ b/config/terraform/aws/route53.tf
@@ -77,9 +77,9 @@ resource "aws_route53_record" "qrcode" {
   }
 
   alias {
-    name                   = aws_lb.qrcode.dns_name
-    zone_id                = aws_lb.qrcode.zone_id
-    evaluate_target_health = true
+    name                   = aws_cloudfront_distribution.qrcode.domain_name
+    zone_id                = aws_cloudfront_distribution.qrcode.hosted_zone_id
+    evaluate_target_health = false
   }
 }
 

--- a/config/terraform/aws/s3.tf
+++ b/config/terraform/aws/s3.tf
@@ -104,6 +104,7 @@ resource "aws_s3_bucket_policy" "web_distribution" {
 ###
 resource "aws_s3_bucket" "cloudfront_logs" {
 
+  # tfsec:ignore:AWS002 Logging not required in Staging
   # tfsec:ignore:AWS077 Don't need to version these they should expire and are ephemeral
 
   bucket = "covid-portal-${var.environment}-cloudfront-logs"

--- a/config/terraform/aws/s3.tf
+++ b/config/terraform/aws/s3.tf
@@ -98,3 +98,44 @@ resource "aws_s3_bucket_policy" "web_distribution" {
   bucket = aws_s3_bucket.portal_maintenance_mode.id
   policy = data.aws_iam_policy_document.web_distribution.json
 }
+
+###
+# AWS S3 bucket - cloudfront log target
+###
+resource "aws_s3_bucket" "cloudfront_logs" {
+
+  # tfsec:ignore:AWS077 Don't need to version these they should expire and are ephemeral
+
+  bucket = "covid-portal-${var.environment}-cloudfront-logs"
+  server_side_encryption_configuration {
+    rule {
+      apply_server_side_encryption_by_default {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+  lifecycle_rule {
+    enabled = true
+
+    expiration {
+      days = 90
+    }
+  }
+
+  # awslogsdelivery account needs full control for cloudfront logging
+  # https://docs.aws.amazon.com/AmazonCloudFront/latest/DeveloperGuide/AccessLogs.html#AccessLogsBucketAndFileOwnership
+  grant {
+    id          = "c4c1ede66af53448b93c283ce9448c4ba468c9432aa01d700d3878632f77d2d0"
+    type        = "CanonicalUser"
+    permissions = ["FULL_CONTROL"]
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "cloudfront_logs" {
+  bucket = aws_s3_bucket.cloudfront_logs.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}

--- a/config/terraform/aws/shield.tf
+++ b/config/terraform/aws/shield.tf
@@ -1,3 +1,9 @@
+# Enable shield on QR code CloudFront distribution
+resource "aws_shield_protection" "cloudfront_qrcode_distribution" {
+  name         = "qrcode_cloudfront_covidportal"
+  resource_arn = aws_cloudfront_distribution.qrcode.arn
+}
+
 # Enable shield on Route53 hosted zone
 resource "aws_shield_protection" "route53_covidportal" {
   name         = "route53_covidportal"

--- a/config/terraform/aws/variables.tf
+++ b/config/terraform/aws/variables.tf
@@ -232,3 +232,11 @@ variable "rds_server_instance_class" {
 variable "route53_zone_name" {
   type = string
 }
+
+###
+# CloudFront - cloudfront.tf
+###
+variable "cloudfront_qrcode_custom_header" {
+  type        = string
+  description = "Header to authenticate CloudFront to QR code ALB"
+}

--- a/config/terraform/aws/waf.tf
+++ b/config/terraform/aws/waf.tf
@@ -178,13 +178,70 @@ resource "aws_wafv2_web_acl" "covidportal_acl" {
     metric_name                = "covid_portal_global_rule"
     sampled_requests_enabled   = false
   }
-
-
 }
 
+###
+# AWS WAF - QR Code ALB
+# Only allow requests to the ALB if they have the CloudFront custom header
+###
 resource "aws_wafv2_web_acl" "qrcode_acl" {
   name  = "qrcode"
   scope = "REGIONAL"
+
+  default_action {
+    block {}
+  }
+
+  rule {
+    name     = "CloudFrontCustomHeader"
+    priority = 201
+
+    action {
+      allow {}
+    }
+
+    statement {
+      byte_match_statement {
+        positional_constraint = "EXACTLY"
+        field_to_match {
+          single_header {
+            name = "covidqrcode"
+          }
+        }
+        search_string = var.cloudfront_qrcode_custom_header
+        text_transformation {
+          priority = 1
+          type     = "NONE"
+        }
+      }
+    }
+
+    visibility_config {
+      cloudwatch_metrics_enabled = true
+      metric_name                = "CloudFrontCustomHeader"
+      sampled_requests_enabled   = false
+    }
+  }
+
+  tags = {
+    (var.billing_tag_key) = var.billing_tag_value
+  }
+
+  visibility_config {
+    cloudwatch_metrics_enabled = true
+    metric_name                = "covid_portal_global_rule"
+    sampled_requests_enabled   = false
+  }
+}
+
+###
+# AWS WAF - QR Code CloudFront distribution
+###
+resource "aws_wafv2_web_acl" "qrcode_cdn_acl" {
+  provider = aws.us-east-1
+
+  name  = "qrcode_cdn"
+  scope = "CLOUDFRONT"
 
   default_action {
     allow {}
@@ -490,4 +547,11 @@ resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_portal" {
 resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_qrcode" {
   log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs_qrcode.arn]
   resource_arn            = aws_wafv2_web_acl.qrcode_acl.arn
+}
+
+resource "aws_wafv2_web_acl_logging_configuration" "firehose_waf_logs_qrcode_cdn" {
+  provider = aws.us-east-1
+
+  log_destination_configs = [aws_kinesis_firehose_delivery_stream.firehose_waf_logs_qrcode_cdn.arn]
+  resource_arn            = aws_wafv2_web_acl.qrcode_cdn_acl.arn
 }


### PR DESCRIPTION
# Summary
This creates a CloudFront distribution for QR code that does the following:

1. Cache all GET/HEAD requests, respecting response cache headers.
2. Cache `/static/*` GET/HEAD requests for 1 week, relying on cache busting in asset filenames to keep cached items fresh.

# Expected changes
1. Create QR code CloudFront distribution.
2. Create S3 logging bucket for CloudFront.
2. Create Kinesis delivery stream for QR code WAF logs.
2. Update QR code DNS record to point to CloudFront.
3. Create new WAF ACL for QR code load balancers (only allows requests with custom HTTP header from CloudFront).
4. Attach existing QR code WAF ACL to CloudFront.
5. Update MaintenanceMode CloudFront distribution to a lower price class (since we only allow traffic from Canada).

The new traffic flow will now be:
```
Request → CloudFront → ALB → ECS
```

Related #682 